### PR TITLE
Fix asset path.

### DIFF
--- a/config/voyager.php
+++ b/config/voyager.php
@@ -27,7 +27,7 @@ return [
     |
     */
 
-    'assets_path' => '/vendor/tcg/voyager/assets',
+    'assets_path' => asset('/vendor/tcg/voyager/assets'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Perhaps you can test if it works on your install too.
I had the issue that all of Voyager's assets were not loaded, because the base url was not localhost but localhost/myapp/public.
Using the asset() helper, the files are loaded properly from the assets folder.
