### PR TITLE
Use ::class property in config file

### DIFF
--- a/config/voyager.php
+++ b/config/voyager.php
@@ -2,7 +2,7 @@
 
 return [
 
-    
+
     /*
     |--------------------------------------------------------------------------
     | User config
@@ -15,7 +15,7 @@ return [
     'user' => [
         'add_default_role_on_register' => true,
         'default_role' => 'user',
-        'namespace' => '\\App\\User'
+        'namespace' => App\User::class,
     ],
 
     /*


### PR DESCRIPTION
Looks a bit cleaner than the escaped backslashes

I also think 'model' would be a more suitable name than 'namespace' but changing that would be a breaking change