### PR TITLE
Fix issue for update column to user table or any existing table

### DIFF
--- a/src/Controllers/VoyagerDatabaseController.php
+++ b/src/Controllers/VoyagerDatabaseController.php
@@ -142,9 +142,13 @@ class VoyagerDatabaseController extends Controller
 				//Reorder the rows
 				$field_name = (string)$request->field[$index];
 				if($index > 0){
-					\DB::statement("ALTER TABLE " . (string)$table_name . " MODIFY COLUMN " . $field_name . " " . $table_type_array[$field_name] . $table_default_array[$field_name] . $table_null_array[$field_name] . " AFTER " . $request->field[$index-1]);
+					if($field_name!='id') {
+						\DB::statement("ALTER TABLE " . (string)$table_name . " MODIFY COLUMN " . $field_name . " " . $table_type_array[$field_name] . $table_default_array[$field_name] . $table_null_array[$field_name] . " AFTER " . $request->field[$index - 1]);
+					}
 				} else {
-					\DB::statement("ALTER TABLE " . (string)$table_name . " MODIFY COLUMN " . $field_name . " " . $table_type_array[$field_name] . $table_default_array[$field_name] . $table_null_array[$field_name] . " FIRST");
+					if($field_name!='id'){
+						\DB::statement("ALTER TABLE " . (string)$table_name . " MODIFY COLUMN " . $field_name . " " . $table_type_array[$field_name] . $table_default_array[$field_name] . $table_null_array[$field_name] . " FIRST");
+					}
 				}
 			}
 


### PR DESCRIPTION
I think we don’t need to edit 'ID' column because if its have any relationship with other table. so if we update id table its not work.
![screenshot from 2016-11-03 16 57 20](https://cloud.githubusercontent.com/assets/5574857/19963809/538fd886-a1e8-11e6-8382-c68f53c09b41.png)

So I skip edit command where column is  'ID' .

You can also check to add or update your user table its show an error like below: 
QueryException in Connection.php line 769: SQLSTATE[HY000]: General error: 1833 Cannot change column 'id': used in a foreign key constraint 'user_roles_user_id_foreign' of table 'test-app.user_roles' (SQL: ALTER TABLE users MODIFY COLUMN id int(10) unsigned NOT NULL FIRST)