### PR TITLE
test using php 7.1, hhvm, and nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,17 @@ sudo: true
 php:
 - 5.6
 - 7.0
+- 7.1
+- hhvm
+- nightly
+
+matrix:
+  fast_finish: true
+ 
+  allow_failures:
+    - php: 7.1
+    - php: hhvm
+    - php: nightly
 
 services:
   - mysql


### PR DESCRIPTION
allow failures on 7.1, hhvm, and nightly builds