### PR TITLE
Register dependency providers in VoyagerServiceProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Add the Voyager service provider as well as the Image Intervention service provi
 
 ```
 TCG\Voyager\VoyagerServiceProvider::class,
-Intervention\Image\ImageServiceProvider::class,
 ```
 
 Lastly, we can install voyager by running

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -15,6 +15,13 @@ class VoyagerServiceProvider extends ServiceProvider
     private $routeNamespace = 'TCG\\Voyager\\Controllers';
 
     /**
+     * Dependency providers to regiser.
+     */
+    private $providers = [
+        \Intervention\Image\ImageServiceProvider::class,
+    ];
+
+    /**
      * Bootstrap the application services.
      *
      * @param Router $router
@@ -50,6 +57,7 @@ class VoyagerServiceProvider extends ServiceProvider
     public function register()
     {
         $this->registerResources();
+        $this->registerProviders();
 
         /*
          * These calls are not needed.
@@ -114,6 +122,16 @@ class VoyagerServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../publishable/views/' => resource_path('views')
         ], 'views');
+    }
+
+    /**
+     * Register dependency service providers
+     */
+    private function registerProviders()
+    {
+        foreach($this->providers as $provider) {
+            $this->app->register($provider);
+        }
     }
 
 }


### PR DESCRIPTION
Register the intervention/image service provider from in the VoyagerServiceProvider. 
Users of the package don't have to register that provider manually anymore.

I also removed the provider in the installation instructions in the readme.md file.