### PR TITLE
Fixed delete actions

### DIFF
--- a/src/views/bread/browse.blade.php
+++ b/src/views/bread/browse.blade.php
@@ -96,13 +96,21 @@
         });
 
         $('td').on('click', '.delete', function (e) {
-            id = $(e.target).data('id');
+            var id = $(this).data('id');
+            var form = $('#delete_form')[0];
+            var action = parseActionUrl(form.action, id);
 
-            $('#delete_form')[0].action += '/' + id;
+            form.action = action;
 
             $('#delete_modal').modal('show');
+
         });
 
-
+        function parseActionUrl(action, id) {
+            if (action.match(/\/[0-9]+$/)) {
+                return action.replace(/([0-9]+$)/, id);
+            }
+            return action + '/' + id;
+        }
     </script>
 @stop


### PR DESCRIPTION
This pull request solve a bug in delete actions of the forms on the lists.

Steps to reproduce the issue:

* Try deleting an item, then **cancel**.

* Now, try deleting the same or another item again.

![fix_delete_actions](https://cloud.githubusercontent.com/assets/9524225/20284196/e97e70c2-aa9a-11e6-9faa-488a03075f62.gif)

The form action url looks something like this.

In the first click

![captura1](https://cloud.githubusercontent.com/assets/9524225/20284257/2a1baf32-aa9b-11e6-8d4b-29a12e246b5a.JPG)

And when we click again

![captura2](https://cloud.githubusercontent.com/assets/9524225/20284318/5a22087a-aa9b-11e6-82c9-a702f2c1ae71.JPG)

I've only changed the way it identifies and analyzes the url of the form action.