### PR TITLE
Added conditional around author_id code in case id is supplied

### DIFF
--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -9,9 +9,11 @@ class Page extends Model
 {
     public function save(array $options = [])
     {
-        // Add the user id as the Author of the post
-        $this->author_id = Auth::user()->id;
+        // If no author has been assigned, assign the current user's id as the author of the post
+        if (! $this->author_id && Auth::user()) {
+            $this->author_id = Auth::user()->id;
+        }
+
         parent::save();
-        // after save code
     }
 }

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -9,9 +9,11 @@ class Post extends Model
 {
     public function save(array $options = [])
     {
-        // Add the user id as the Author of the post
-        $this->author_id = Auth::user()->id;
+        // If no author has been assigned, assign the current user's id as the author of the post
+        if (! $this->author_id && Auth::user()) {
+            $this->author_id = Auth::user()->id;
+        }
+
         parent::save();
-        // after save code
     }
 }


### PR DESCRIPTION
While doing some tests I came across an inconsistency in how a page is saved. The `author_id` is automatically assigned as the current authenticated user. There are a few times that this is not desired behavior:

1. A user is editing a page previously created by a different user.
2. During testing a page needs to be created via Model Factory. In the case where the test does not have a logged in user, a default id needs to be set.

This PR does update any forms for the `author_id`.

There is also a case where a page could be saved where there is no authenticated user and no id was supplied, but that is a big outlier.
 