### PR TITLE
Disable datatables default order (sort)

### DIFF
--- a/publishable/views/admin/posts/browse.blade.php
+++ b/publishable/views/admin/posts/browse.blade.php
@@ -82,7 +82,7 @@
     <script>
 
       $(document).ready(function(){
-        $('#dataTable').DataTable();
+		  $('#dataTable').DataTable({ "order": [] });
       });
 
       $('td').on('click', '.delete', function(e){

--- a/src/views/bread/browse.blade.php
+++ b/src/views/bread/browse.blade.php
@@ -91,7 +91,7 @@
     <script>
 
         $(document).ready(function () {
-            $('#dataTable').DataTable();
+            $('#dataTable').DataTable({ "order": [] });
 
         });
 

--- a/src/views/menus/browse.blade.php
+++ b/src/views/menus/browse.blade.php
@@ -99,7 +99,7 @@
     <script>
 
         $(document).ready(function () {
-            $('#dataTable').DataTable();
+            $('#dataTable').DataTable({ "order": [] });
 
         });
 


### PR DESCRIPTION
Datatables by default will sort the first table column which will cause Eloquent orderBy ignored.