### PR TITLE
Fix create bread

### DIFF
--- a/src/Http/Controllers/VoyagerDatabaseController.php
+++ b/src/Http/Controllers/VoyagerDatabaseController.php
@@ -317,7 +317,7 @@ class VoyagerDatabaseController extends Controller
 
     public function updateDataType(DataType $dataType, $requestData)
     {
-        $success = $dataType->update($requestData);
+        $success = $dataType->fill($requestData)->save();
         $columns = Schema::getColumnListing($dataType->name);
 
         foreach ($columns as $column) {


### PR DESCRIPTION
Fix #222 

It wasn't able to run `$dataType->update($requestData)` on an model that didn't exists.
Changing it to `$dataType->fill($requestData)->save()` work both for updating existing and creating new bread.