### PR TITLE
Set NULL for empty foreign keys in Bread Controller

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -233,6 +233,15 @@ class VoyagerBreadController extends Controller
             }
 
             $content = $this->getContentBasedOnType($request, $slug, $row);
+
+            if (
+                strtolower($content) === 'null'
+                || (strripos($row->field, '_id') !== false && empty($content))
+            ) {
+                $data->{$row->field} = null;
+                continue;
+            }
+
             if ($content === null) {
                 if (isset($data->{$row->field})) {
                     $content = $data->{$row->field};


### PR DESCRIPTION
Not only Seeders but also BreadController.Be sure the `0` or EMPTY STRING of foreign key (such as `parent_id`) can be changed to `NULL`