### PR TITLE
Update edit-add.blade.php

### DIFF
--- a/resources/views/tools/database/edit-add.blade.php
+++ b/resources/views/tools/database/edit-add.blade.php
@@ -269,7 +269,7 @@
                 $('#' + unique_id).find('.fieldName').val('created_at & updated_at');
                 $('#' + unique_id).find('.fieldName').attr('readonly', 'readonly');
                 $('#' + unique_id).find('.fieldDefault').val('CURRENT_TIMESTAMP').attr('readonly', 'readonly');
-                $('#' + unique_id).find('.fieldType').val('timestamp').attr('readonly', 'readonly').prop('disabled', 'true');
+                $('#' + unique_id).find('.fieldType').val('timestamp').attr('readonly', 'readonly');
                 $('#' + unique_id).find('.fieldNull').parent().hide();
                 $('#' + unique_id).find('.fieldKey').hide();
             } else {


### PR DESCRIPTION
~~fix Undefined offset: 3~~

Update:

In menu tools > database add new table and add timestamp fields will appear **Undefined offset: 3** exception.

Voyager version 0.9.34.

Repair:

Modify the **edit-add.blade.php** file to line 263
`$('#' + unique_id).find('.fieldType').val('timestamp').attr('readonly', 'readonly').attr('disabled', 'disabled');`

Remove the disable attribute, replace with
`$('#' + unique_id).find('.fieldType').val('timestamp').attr('readonly', 'readonly');`


