### PR TITLE
Fixed issue related to env('DB_CONNECTION') are null when routes & configs are cached.

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::group(['middleware' => ['web', 'admin.user']], function () {
         endforeach;
     } catch (\InvalidArgumentException $e) {
         throw new \InvalidArgumentException("Custom routes hasn't been configured because: ".$e->getMessage(), 1);
+    } catch (\Exception $e) {
     }
 
     // Menu Routes

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,11 +17,15 @@ Route::group(['middleware' => ['web', 'admin.user']], function () {
         },
     ]);
 
-    if (env('DB_CONNECTION') !== null && Schema::hasTable('data_types')):
+    try {
+
         foreach (TCG\Voyager\Models\DataType::all() as $dataTypes):
             Route::resource($dataTypes->slug, 'VoyagerBreadController');
-    endforeach;
-    endif;
+        endforeach;
+
+    } catch (\InvalidArgumentException $e) {
+        throw new \InvalidArgumentException("Custom routes hasn't been configured because: " . $e->getMessage(), 1);
+    }
 
     // Menu Routes
     Route::get('menus/{id}/builder/', ['uses' => 'VoyagerMenuController@builder', 'as' => 'voyager.menu.builder']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,13 +18,11 @@ Route::group(['middleware' => ['web', 'admin.user']], function () {
     ]);
 
     try {
-
         foreach (TCG\Voyager\Models\DataType::all() as $dataTypes):
             Route::resource($dataTypes->slug, 'VoyagerBreadController');
         endforeach;
-
     } catch (\InvalidArgumentException $e) {
-        throw new \InvalidArgumentException("Custom routes hasn't been configured because: " . $e->getMessage(), 1);
+        throw new \InvalidArgumentException("Custom routes hasn't been configured because: ".$e->getMessage(), 1);
     }
 
     // Menu Routes


### PR DESCRIPTION
As mentioned in the documentation, on [Upgrade Guide 5.2 from 5.1](https://laravel.com/docs/5.3/upgrade#upgrade-5.2.0):

```
Caching And Env

If you are using the config:cache command during deployment, you must make sure that you are only calling the env function from within your configuration files, and not from anywhere else in your application.

If you are calling env from within your application, it is strongly recommended you add proper configuration values to your configuration files and call env from that location instead, allowing you to convert your env calls to config calls.
```
So, my proposal only change the if statement call to a try-catch block.

Ref #289 & #284 