### PR TITLE
Test on PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 matrix:
   fast_finish: true
 
   allow_failures:
-    - php: 7.1
+    - php: 7.2
     - php: nightly
 
 services:


### PR DESCRIPTION
- Test on PHP 7.2 (allow failures)
- Don’t allow failures on PHP 7.1 anymore (#294)