### PR TITLE
Delete-menu-patch

### DIFF
--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -157,7 +157,7 @@
             $('.dd').nestable({/* config options */});
             $('.item_actions').on('click', '.delete', function (e) {
                 id = $(e.target).data('id');
-                $('#delete_form')[0].action += '/' + id;
+                $('#delete_form')[0].action += id;
                 $('#delete_modal').modal('show');
             });
 


### PR DESCRIPTION
Fix for issue in delete url for menu item.
   Url built with javascript is for instance /admin/menu/delete_menu_item//3
This is because id in route voyager.menu.delete_menu_item is menu/delete_menu_item/{id} and an extra "/" was added with JS.