### PR TITLE
Move menu items from view to database

### DIFF
--- a/publishable/database/seeds/MenuItemsTableSeeder.php
+++ b/publishable/database/seeds/MenuItemsTableSeeder.php
@@ -140,21 +140,6 @@ class MenuItemsTableSeeder extends Seeder
 
             $menuItem = MenuItem::firstOrNew([
                 'menu_id'    => $menu->id,
-                'title'      => 'Tools',
-                'url'        => route('voyager.menus.index', [], false),
-            ]);
-            if (!$menuItem->exists) {
-                $menuItem->fill([
-                    'target'     => '_self',
-                    'icon_class' => 'voyager-list',
-                    'color'      => null,
-                    'parent_id'  => $toolsMenuItem->id,
-                    'order'      => 10,
-                ])->save();
-            }
-
-            $menuItem = MenuItem::firstOrNew([
-                'menu_id'    => $menu->id,
                 'title'      => 'Database',
                 'url'        => route('voyager.database.index', [], false),
             ]);
@@ -164,7 +149,7 @@ class MenuItemsTableSeeder extends Seeder
                     'icon_class' => 'voyager-data',
                     'color'      => null,
                     'parent_id'  => $toolsMenuItem->id,
-                    'order'      => 11,
+                    'order'      => 10,
                 ])->save();
             }
 
@@ -179,7 +164,7 @@ class MenuItemsTableSeeder extends Seeder
                     'icon_class' => 'voyager-settings',
                     'color'      => null,
                     'parent_id'  => null,
-                    'order'      => 12,
+                    'order'      => 11,
                 ])->save();
             }
         }

--- a/publishable/database/seeds/MenuItemsTableSeeder.php
+++ b/publishable/database/seeds/MenuItemsTableSeeder.php
@@ -122,6 +122,66 @@ class MenuItemsTableSeeder extends Seeder
                     'order'      => 2,
                 ])->save();
             }
+
+            $toolsMenuItem = MenuItem::firstOrNew([
+                'menu_id'    => $menu->id,
+                'title'      => 'Tools',
+                'url'        => '',
+            ]);
+            if (!$toolsMenuItem->exists) {
+                $toolsMenuItem->fill([
+                    'target'     => '_self',
+                    'icon_class' => 'voyager-tools',
+                    'color'      => null,
+                    'parent_id'  => null,
+                    'order'      => 9,
+                ])->save();
+            }
+
+            $menuItem = MenuItem::firstOrNew([
+                'menu_id'    => $menu->id,
+                'title'      => 'Tools',
+                'url'        => route('voyager.menus.index', [], false),
+            ]);
+            if (!$menuItem->exists) {
+                $menuItem->fill([
+                    'target'     => '_self',
+                    'icon_class' => 'voyager-list',
+                    'color'      => null,
+                    'parent_id'  => $toolsMenuItem->id,
+                    'order'      => 10,
+                ])->save();
+            }
+
+            $menuItem = MenuItem::firstOrNew([
+                'menu_id'    => $menu->id,
+                'title'      => 'Database',
+                'url'        => route('voyager.database.index', [], false),
+            ]);
+            if (!$menuItem->exists) {
+                $menuItem->fill([
+                    'target'     => '_self',
+                    'icon_class' => 'voyager-data',
+                    'color'      => null,
+                    'parent_id'  => $toolsMenuItem->id,
+                    'order'      => 11,
+                ])->save();
+            }
+
+            $menuItem = MenuItem::firstOrNew([
+                'menu_id'    => $menu->id,
+                'title'      => 'Settings',
+                'url'        => route('voyager.settings.index', [], false),
+            ]);
+            if (!$menuItem->exists) {
+                $menuItem->fill([
+                    'target'     => '_self',
+                    'icon_class' => 'voyager-settings',
+                    'color'      => null,
+                    'parent_id'  => null,
+                    'order'      => 12,
+                ])->save();
+            }
         }
     }
 }

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -157,54 +157,6 @@ $menuExpanded = isset($_COOKIE['expandedMenu']) && $_COOKIE['expandedMenu'] == 1
                     </div>
 
                     <?= Menu::display('admin', 'admin_menu'); ?>
-
-                        <?php
-                            $user = TCG\Voyager\Models\User::find(Auth::id());
-                        ?>
-
-                        @if ($user->hasPermission('browse_menus') || $user->hasPermission('browse_database'))
-                        <li class="dropdown">
-                            <a data-toggle="collapse" href="#tools-dropdown-element">
-                                <span class="icon voyager-tools"></span>
-                                <span class="title">Tools</span>
-                                <span class="site-menu-arrow"></span>
-                            </a>
-
-                            <div id="tools-dropdown-element" class="panel-collapse collapse">
-                                <div class="panel-body">
-                                    <ul class="nav navbar-nav">
-                                        @if ($user->hasPermission('browse_menus'))
-                                        <li>
-                                            <a href="{{route('voyager.menus.index')}}">
-                                                <span class="icon voyager-list"></span>
-                                                <span class="title">Menu Builder</span>
-                                            </a>
-                                        </li>
-                                        @endif
-                                        @if ($user->hasPermission('browse_database'))
-                                        <li>
-                                            <a class="animsition-link" href="{{ route('voyager.database.index') }}">
-                                                <span class="icon voyager-data"></span>
-                                                <span class="title">Database</span>
-                                            </a>
-                                        </li>
-                                        @endif
-                                    </ul>
-                                </div>
-                            </div>
-                        </li>
-                        @endif
-                        @if ($user->hasPermission('browse_settings'))
-                        <li>
-                            <a href="{{ route('voyager.settings.index') }}">
-                                <span class="icon voyager-settings"></span>
-                                <span class="title">Settings</span>
-                            </a>
-                        </li>
-                        @endif
-                    </ul>
-                    <!-- /.navbar-collapse -->
-                    </div>
                 </nav>
             </div>
             <!-- Main Content -->

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -329,7 +329,7 @@ class Menu extends Model
             return '';
         }
 
-        return '<ul class="nav navbar-nav">'.$output; // TODO: Check if is missing a closing ul tag!!
+        return '<ul class="nav navbar-nav">'.$output.'</ul>';
     }
 
     /**


### PR DESCRIPTION
For people already having installed the `v0.10`, please rerun `php artisan db:seed --class=MenuItemsTableSeeder` to get the removed items.