### PR TITLE
Make admin command

### DIFF
--- a/src/Commands/AdminCommand.php
+++ b/src/Commands/AdminCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace TCG\Voyager\Commands;
+
+use TCG\Voyager\Models\Role;
+use TCG\Voyager\Models\User;
+use Illuminate\Console\Command;
+use TCG\Voyager\Models\Permission;
+use Symfony\Component\Console\Input\InputOption;
+
+class AdminCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'voyager:admin';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Make sure a user have the admin role, and that the role has all permissions.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $email = $this->argument('email');
+
+        $role = Role::firstOrNew([
+            'name' => 'admin',
+        ]);
+        if (!$role->exists) {
+            $role->fill([
+                'display_name' => 'Administrator',
+            ])->save();
+        }
+
+        $permissions = Permission::all();
+
+        $role->permissions()->sync(
+            $permissions->pluck('id')->all()
+        );
+
+        $user = User::where('email', $email)->firstOrFail();
+        $user->role_id = $role->id;
+        $user->save();
+
+        $this->info('The user have now full access to your site.');
+    }
+
+    /**
+     * Get command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['email', InputOption::VALUE_REQUIRED, 'The email of the user.', null],
+        ];
+    }
+}

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -92,5 +92,6 @@ class VoyagerServiceProvider extends ServiceProvider
     {
         $this->commands(Commands\InstallCommand::class);
         $this->commands(Commands\ControllersCommand::class);
+        $this->commands(Commands\AdminCommand::class);
     }
 }


### PR DESCRIPTION
This is ment for users that install Voyager on an existing system or without the dummy data that would like to make their user admin and have all roles or cases when the admin have messed around with the permissions and no longer have access to it.

```
php artisan voyager:admin admin@admin.com
```
It will now take the user with that email (`admin@admin.com`) and give that user the role with the name `admin`. However if that does not exists, it will create it. Then it will give that role **all** permissions.