### PR TITLE
When user is saved in admin if the image is not set, set it to default

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -12,6 +12,19 @@ class User extends AuthUser
 
     protected $fillable = ['name', 'email', 'password', 'remember_token', 'role_id'];
 
+    /**
+     * On save make sure to set the default avatar if image is not set
+     */
+    public function save(array $options = [])
+    {
+        // If no avatar has been set, set it to the default
+        if (!$this->avatar) {
+            $this->avatar = "users/default.png";
+        }
+
+        parent::save();
+    }
+
     public function getNameAttribute($value)
     {
         return ucwords($value);

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -13,13 +13,13 @@ class User extends AuthUser
     protected $fillable = ['name', 'email', 'password', 'remember_token', 'role_id'];
 
     /**
-     * On save make sure to set the default avatar if image is not set
+     * On save make sure to set the default avatar if image is not set.
      */
     public function save(array $options = [])
     {
         // If no avatar has been set, set it to the default
         if (!$this->avatar) {
-            $this->avatar = "users/default.png";
+            $this->avatar = 'users/default.png';
         }
 
         parent::save();


### PR DESCRIPTION
When a new user is created in the admin and they do not specify an avatar it shows as a broken image when they login. 

With this pull request now anytime the avatar is not set it will set it to the default 'users/default.png' image.