### PR TITLE
Adding functionality for views to be overriden from the resource folder

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -38,7 +38,9 @@ class VoyagerBreadController extends Controller
 
         $view = 'voyager::bread.browse';
 
-        if (view()->exists("voyager::$slug.browse")) {
+        if (view()->exists("voyager.$slug.browse")) {
+            $view = "voyager.$slug.browse";
+        } elseif (view()->exists("voyager::$slug.browse")) {
             $view = "voyager::$slug.browse";
         }
 
@@ -72,7 +74,9 @@ class VoyagerBreadController extends Controller
 
         $view = 'voyager::bread.read';
 
-        if (view()->exists("voyager::$slug.read")) {
+        if (view()->exists("voyager.$slug.read")) {
+            $view = "voyager.$slug.read";
+        } elseif (view()->exists("voyager::$slug.read")) {
             $view = "voyager::$slug.read";
         }
 
@@ -106,7 +110,9 @@ class VoyagerBreadController extends Controller
 
         $view = 'voyager::bread.edit-add';
 
-        if (view()->exists("voyager::$slug.edit-add")) {
+        if (view()->exists("voyager.$slug.edit-add")) {
+            $view = "voyager.$slug.edit-add";
+        } elseif (view()->exists("voyager::$slug.edit-add")) {
             $view = "voyager::$slug.edit-add";
         }
 
@@ -158,7 +164,9 @@ class VoyagerBreadController extends Controller
 
         $view = 'voyager::bread.edit-add';
 
-        if (view()->exists("voyager::$slug.edit-add")) {
+        if (view()->exists("voyager.$slug.edit-add")) {
+            $view = "voyager.$slug.edit-add";
+        } elseif (view()->exists("voyager::$slug.edit-add")) {
             $view = "voyager::$slug.edit-add";
         }
 


### PR DESCRIPTION
If a user creates a new folder located at `resource/views/voyager` they can add any folder with the BREAD slug and that view would be used instead of the default voyager view.

As an example, say that we created a BREAD from the `products` table with a slug name of `products` we could then include these following views in our resources/views folder:

 - resources/views/voyager/products/browse.blade.php (browse & delete)
 - resources/views/voyager/products/read.blade.php (read)
 - resources/views/voyager/products/edit-add.blade.php (edit and add)

And those views would be used when visiting the Browse, Read, Edit, Add, or Delete routes of the voyager admin for the products section.