### PR TITLE
Adding fix for the menu builder and the bootstrap menu

### DIFF
--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -156,22 +156,23 @@
         $(document).ready(function () {
             $('.dd').nestable({/* config options */});
             $('.item_actions').on('click', '.delete', function (e) {
-                id = $(e.target).data('id');
+                id = $(e.currentTarget).data('id');
                 $('#delete_form')[0].action = $('#delete_form')[0].action.replace("__id",id);
                 $('#delete_modal').modal('show');
             });
 
             $('.item_actions').on('click', '.edit', function (e) {
-                id = $(e.target).data('id');
-                $('#edit_title').val($(e.target).data('title'));
-                $('#edit_url').val($(e.target).data('url'));
-                $('#edit_icon_class').val($(e.target).data('icon_class'));
-                $('#edit_color').val($(e.target).data('color'));
+                id = $(e.currentTarget).data('id');
+                console.log(id);
+                $('#edit_title').val($(e.currentTarget).data('title'));
+                $('#edit_url').val($(e.currentTarget).data('url'));
+                $('#edit_icon_class').val($(e.currentTarget).data('icon_class'));
+                $('#edit_color').val($(e.currentTarget).data('color'));
                 $('#edit_id').val(id);
 
-                if ($(e.target).data('target') == '_self') {
+                if ($(e.currentTarget).data('target') == '_self') {
                     $("#edit_target").val('_self').change();
-                } else if ($(e.target).data('target') == '_blank') {
+                } else if ($(e.currentTarget).data('target') == '_blank') {
                     $("#edit_target option[value='_self']").removeAttr('selected');
                     $("#edit_target option[value='_blank']").attr('selected', 'selected');
                     $("#edit_target").val('_blank');

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -119,13 +119,16 @@ class Menu extends Model
                 return $value->parent_id == $item->id;
             });
 
+            $caret = '';
+
             if ($children_menu_items->count() > 0) {
                 if ($li_class != '') {
                     $li_class = rtrim($li_class, '"').' dropdown"';
                 } else {
                     $li_class = ' class="dropdown"';
                 }
-                $a_attrs = 'class="dropdown-toggle" ';
+                $a_attrs = 'class="dropdown-toggle" data-toggle="dropdown" ';
+                $caret = '<span class="caret"></span>';
             }
 
             $icon = '';
@@ -144,7 +147,7 @@ class Menu extends Model
                 $styles = ' style="background-color:'.$item->color.'"';
             }
 
-            $output .= '<li'.$li_class.'><a '.$a_attrs.' href="'.$item->url.'" target="'.$item->target.'"'.$styles.'>'.$icon.'<span>'.$item->title.'</span></a>';
+            $output .= '<li'.$li_class.'><a '.$a_attrs.' href="'.$item->url.'" target="'.$item->target.'"'.$styles.'>'.$icon.'<span>'.$item->title.'</span>'.$caret.'</a>';
 
             if ($children_menu_items->count() > 0) {
                 $output = self::buildBootstrapOutput($menuItems, $output, $options, $request, $item->id);


### PR DESCRIPTION
Currently when editing menus from the Menu builder it will occasionally be blank in the modal and you will have to close it and open it again. This is because if you click on the text inside the 'Edit' button the `e.target` does not register and grab the `data` attributes for that menu item. Instead `e.currentTarget` needs to be used so the action of the button stays consistent.

I've also added a fix for the current bootstrap menu. Adding a dropdown and caret icon if it is a dropdown 👍 