### PR TITLE
Optionally paginate data type on server-side, avoiding dataTable 

### DIFF
--- a/publishable/database/migrations/2016_12_26_201236_data_types__add__server_side.php
+++ b/publishable/database/migrations/2016_12_26_201236_data_types__add__server_side.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DataTypesAddServerSide extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('data_types', function (Blueprint $table) {
+            $table->tinyInteger('server_side')->default(0)->after('generate_permissions');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('data_types', function (Blueprint $table) {
+            $table->dropColumn('server_side');
+        });
+    }
+}

--- a/publishable/database/migrations/2016_12_26_201236_data_types__add__server_side.php
+++ b/publishable/database/migrations/2016_12_26_201236_data_types__add__server_side.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DataTypesAddServerSide extends Migration
 {

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -64,6 +64,16 @@
                 </div>
             </div>
         </div>
+        @if ($dataType->server_side)
+            <div class="row">
+                <div class="col-sm-5">
+                    <div role="status" aria-live="polite">Showing {{ $dataTypeContent->firstItem() }} to {{ $dataTypeContent->lastItem() }} of {{ $dataTypeContent->total() }} entries</div>
+                </div>
+                <div class="col-sm-7">
+                    {{ $dataTypeContent->links() }}
+                </div>
+            </div>
+        @endif
     </div>
 
     <div class="modal modal-danger fade" tabindex="-1" id="delete_modal" role="dialog">
@@ -92,9 +102,11 @@
 @section('javascript')
     <!-- DataTables -->
     <script>
-        $(document).ready(function () {
-            $('#dataTable').DataTable({ "order": [] });
-        });
+        @if (!$dataType->server_side)
+            $(document).ready(function () {
+                $('#dataTable').DataTable({ "order": [] });
+            });
+        @endif
 
         $('td').on('click', '.delete', function (e) {
             var form = $('#delete_form')[0];

--- a/resources/views/tools/database/edit-add-bread.blade.php
+++ b/resources/views/tools/database/edit-add-bread.blade.php
@@ -239,14 +239,22 @@
                                 <input type="text" class="form-control" name="model_name" placeholder="Model Class Name"
                                        value="@if(isset($dataType->model_name)){{ $dataType->model_name }}@else{{ $model_name }}@endif">
                             </div>
-                            <div class="form-group">
-                                <label for="email">Generate Permissions</label><br>
-                                <?php $checked = (isset($dataType->generate_permissions) && $dataType->generate_permissions == 1) ? true : (isset($generate_permissions) && $generate_permissions) ? true : false; ?>
-                                <input type="checkbox" name="generate_permissions" class="toggleswitch"
-                                       @if($checked) checked @endif>
+                            <div class="row clearfix">
+                                <div class="col-md-6 form-group">
+                                    <label for="generate_permissions">Generate Permissions</label><br>
+                                    <?php $checked = (isset($dataType->generate_permissions) && $dataType->generate_permissions == 1) ? true : (isset($generate_permissions) && $generate_permissions) ? true : false; ?>
+                                    <input type="checkbox" name="generate_permissions" class="toggleswitch"
+                                           @if($checked) checked @endif>
+                                </div>
+                                <div class="col-md-6 form-group">
+                                    <label for="server_side">Server-side Pagination</label><br>
+                                    <?php $checked = (isset($dataType->server_side) && $dataType->server_side == 1) ? true : (isset($server_side) && $server_side) ? true : false; ?>
+                                    <input type="checkbox" name="server_side" class="toggleswitch"
+                                           @if($checked) checked @endif>
+                                </div>
                             </div>
                             <div class="form-group">
-                                <label for="email">Description</label>
+                                <label for="description">Description</label>
                                 <textarea class="form-control" name="description"
                                           placeholder="Description">@if(isset($dataType->description)){{ $dataType->description }}@endif</textarea>
                             </div>

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -9,6 +9,8 @@ use TCG\Voyager\Voyager;
 
 class VoyagerBreadController extends Controller
 {
+    const SERVER_SIDE_PAGINATION = true;
+
     //***************************************
     //               ____
     //              |  _ \
@@ -32,21 +34,28 @@ class VoyagerBreadController extends Controller
         // Check permission
         Voyager::can('browse_'.$dataType->name);
 
-        // Next Get the actual content from the MODEL that corresponds to the slug DataType
-        if (strlen($dataType->model_name) != 0) {
-            $model = app($dataType->model_name);
-
-            if ($model->timestamps) {
-                $dataTypeContent = $model->latest()->get();
-            } else {
-                $dataTypeContent = $model->orderBy('id', 'DESC')->get();
-            }
-        } else {
-            // If Model doest exist, get data from table name
-            $dataTypeContent = DB::table($dataType->name)->get();
+        if (self::SERVER_SIDE_PAGINATION) {
+            $view = 'voyager::bread.browse-paginated';
+            $dataTypeContent = [];
         }
+        else {
 
-        $view = 'voyager::bread.browse';
+            // Next Get the actual content from the MODEL that corresponds to the slug DataType
+            if (strlen($dataType->model_name) != 0) {
+                $model = app($dataType->model_name);
+
+                if ($model->timestamps) {
+                    $dataTypeContent = $model->latest()->get();
+                } else {
+                    $dataTypeContent = $model->orderBy('id', 'DESC')->get();
+                }
+            } else {
+                // If Model doest exist, get data from table name
+                $dataTypeContent = DB::table($dataType->name)->get();
+            }
+
+            $view = 'voyager::bread.browse';
+        }
 
         if (view()->exists("voyager::$slug.browse")) {
             $view = "voyager::$slug.browse";

--- a/src/Http/Controllers/VoyagerDatabaseController.php
+++ b/src/Http/Controllers/VoyagerDatabaseController.php
@@ -199,6 +199,7 @@ class VoyagerDatabaseController extends Controller
             'display_name_plural'   => Str::plural($displayName),
             'model_name'            => $this->getAppNamespace().Str::studly(Str::singular($table)),
             'generate_permissions'  => true,
+            'server_side'           => false,
         ];
     }
 

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -47,9 +47,14 @@ class DataType extends Model
         $this->attributes['generate_permissions'] = $value ? 1 : 0;
     }
 
+    public function setServerSideAttribute($value)
+    {
+        $this->attributes['server_side'] = $value ? 1 : 0;
+    }
+
     public function updateDataType($requestData)
     {
-        $success = $this->fill($requestData)->save();
+        $success = true;
         $fields = $this->fields();
 
         foreach ($fields as $field) {
@@ -83,6 +88,13 @@ class DataType extends Model
                 $success = $dataRowSuccess;
             }
         }
+
+        $requestData = array_filter(
+            $requestData,
+            function ($value, $key) { return strpos($key, 'field_') !== 0; },
+            ARRAY_FILTER_USE_BOTH
+        );
+        $success = $success && $this->fill($requestData)->save();
 
         if ($this->generate_permissions) {
             Permission::generateFor($this->name);

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -91,7 +91,9 @@ class DataType extends Model
 
         $requestData = array_filter(
             $requestData,
-            function ($value, $key) { return strpos($key, 'field_') !== 0; },
+            function ($value, $key) {
+                return strpos($key, 'field_') !== 0;
+            },
             ARRAY_FILTER_USE_BOTH
         );
         $success = $success && $this->fill($requestData)->save();


### PR DESCRIPTION
As fix for

* [#444 require pagination for browse data](https://github.com/the-control-group/voyager/issues/444)
* [#422 Problem with BREAD for table with 14k+ rows](https://github.com/the-control-group/voyager/issues/422)
* [#404 Datatable server side in Browse](https://github.com/the-control-group/voyager/issues/404)
* [#156 Table view loading 1 200 000 cities from my database](https://github.com/the-control-group/voyager/issues/156)
* [#81 Add server side pagination to browse](https://github.com/the-control-group/voyager/issues/81)

... I have added a new option _server_side_ to paginate the _browse_ view, using the standard Laravel _paginate()_ method instead of the original approach based on _dataTable_. The default is still to use _dataTable_, but this can now be changed by editing a BREAD and setting the switch:

<img width="818" alt="new-switch" src="https://cloud.githubusercontent.com/assets/124634/21486900/2cef23ea-cbbd-11e6-9424-526dd939074b.png">

The result is that even big tables now no longer time out in the browser:

<img width="1083" alt="pagination" src="https://cloud.githubusercontent.com/assets/124634/21486909/75e90c46-cbbd-11e6-822e-5f54dc7a4abd.png">
