### PR TITLE
Adding new condition to escape forward slash in preg_replace

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -298,7 +298,8 @@ class Menu extends Model
             }
 
             // Permission Checker
-            $slug = str_replace('/', '', preg_replace('/^\/'.self::$prefix.'/', '', $item->url));
+            $self_prefix = str_replace('/', '\/', self::$prefix);
+            $slug = str_replace('/', '', preg_replace('/^\/'.$self_prefix.'/', '', $item->url));
             if ($slug != '') {
                 // Get dataType using slug
                 $dataType = self::$dataTypes->first(function ($value) use ($slug) {


### PR DESCRIPTION
This will make it possible for users to specify their admin prefix in a subfolder, with something like:
```
folder1/admin
```
If the forward slash is not escaped, the following code:
```
$slug = str_replace('/', '', preg_replace('/^\/'.self::$prefix.'/', '', $item->url));
```
would throw an error.

This is a fix for that issue.