### PR TITLE
Add new helper methods for permission checking

### DIFF
--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Traits;
 
 use TCG\Voyager\Models\Role;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * @property  \Illuminate\Database\Eloquent\Collection  roles
@@ -41,5 +42,19 @@ trait VoyagerUser
     public function hasPermission($name)
     {
         return in_array($name, $this->role->permissions->pluck('key')->toArray());
+    }
+
+    public function hasPermissionOrFail($permission)
+    {
+        if (!$this->hasPermission($permission)) {
+            throw new UnauthorizedHttpException(null);
+        }
+    }
+
+    public function hasPermissionOrAbort($permission, $statusCode = 403, $message = '')
+    {
+        if (!$this->hasPermission($permission)) {
+            return abort($statusCode, $message);
+        }
     }
 }

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -2,8 +2,8 @@
 
 namespace TCG\Voyager\Traits;
 
-use TCG\Voyager\Models\Role;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use TCG\Voyager\Models\Role;
 
 /**
  * @property  \Illuminate\Database\Eloquent\Collection  roles

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -57,18 +57,44 @@ class Voyager
         require __DIR__.'/../routes/voyager.php';
     }
 
+    // TODO: In next breaking change release, this should return a boolean
     public static function can($permission)
+    {
+        static::canOrFail($permission);
+    }
+
+    public static function canOrFail($permission)
     {
         // Check if permission exist
         $exist = Permission::where('key', $permission)->first();
 
         if ($exist) {
             $user = User::find(Auth::id());
+
             if ($user == null) {
                 throw new UnauthorizedHttpException(null);
             }
+
             if (!$user->hasPermission($permission)) {
                 throw new UnauthorizedHttpException(null);
+            }
+        }
+    }
+
+    public static function canOrAbort($permission, $statusCode = 403, $message = '')
+    {
+        // Check if permission exist
+        $exist = Permission::where('key', $permission)->first();
+
+        if ($exist) {
+            $user = User::find(Auth::id());
+
+            if ($user == null) {
+                return abort($statusCode, $message);
+            }
+
+            if (!$user->hasPermission($permission)) {
+                return abort($statusCode, $message);
             }
         }
     }


### PR DESCRIPTION
Add new helper methods on `Voyager` instance.

- [X] `Voyager::canOrFail('browse_pages')`
- [X] `Voyager::canOrAbort('browse_pages', 403, 'A friendly error message')`

Add new helper methods on `User` object (requires that trait `VoyagerUser` is used)

- [X] `$user->hasPermissionOrFail('browse_pages')`
- [X] `$user->hasPermissionOrAbort('browse_pages', 403, 'A friendly error message')`

In next breaking change release, the `Voyager::can('browse_pages')` will return a `boolean` instead of failing.