### PR TITLE
Migrations independent of users table

### DIFF
--- a/publishable/database/migrations/2016_01_01_000000_add_user_avatar.php
+++ b/publishable/database/migrations/2016_01_01_000000_add_user_avatar.php
@@ -11,7 +11,7 @@ class AddUserAvatar extends Migration
      */
     public function up()
     {
-        Schema::table('users', function ($table) {
+        Schema::table({*users_table*}, function ($table) {
             $table->string('avatar')->default('users/default.png');
         });
     }
@@ -23,7 +23,7 @@ class AddUserAvatar extends Migration
      */
     public function down()
     {
-        Schema::table('users', function ($table) {
+        Schema::table({*users_table*}, function ($table) {
             $table->dropColumn('avatar');
         });
     }

--- a/publishable/database/migrations/2016_10_30_000000_set_user_avatar_nullable.php
+++ b/publishable/database/migrations/2016_10_30_000000_set_user_avatar_nullable.php
@@ -11,7 +11,7 @@ class SetUserAvatarNullable extends Migration
      */
     public function up()
     {
-        Schema::table('users', function ($table) {
+        Schema::table({*users_table*}, function ($table) {
             $table->string('avatar')->nullable()->change();
         });
     }
@@ -23,7 +23,7 @@ class SetUserAvatarNullable extends Migration
      */
     public function down()
     {
-        Schema::table('users', function ($table) {
+        Schema::table({*users_table*}, function ($table) {
             $table->string('avatar')->nullable(false)->change();
         });
     }

--- a/publishable/database/migrations/2016_11_30_131710_add_user_role.php
+++ b/publishable/database/migrations/2016_11_30_131710_add_user_role.php
@@ -13,7 +13,7 @@ class AddUserRole extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table({*users_table*}, function (Blueprint $table) {
             $table->integer('role_id')->default(0)->index();
         });
     }
@@ -25,7 +25,7 @@ class AddUserRole extends Migration
      */
     public function down()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table({*users_table*}, function (Blueprint $table) {
             $table->dropColumn('role_id');
         });
     }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -63,7 +63,17 @@ class InstallCommand extends Command
         $this->info('Publishing the Voyager assets, database, and config files');
         $this->call('vendor:publish', ['--provider' => VoyagerServiceProvider::class]);
         $this->call('vendor:publish', ['--provider' => ImageServiceProviderLaravel5::class]);
-
+        /*
+        * Translate migrations
+        */
+        $this->info('Applying new user namespace table name');
+        $basePath = dirname(__DIR__);
+        $migrationsDirectory = scandir($basePath . '/publishable/database/migrations/');
+        foreach($migrationsDirectory as $migration){
+            $migrationContent = file_get_contents(database_path('migrations').$migration);
+            $migrationContent = str_replace('{*users_table*}', app(config('voyager.user')['namespace'])->getTable(), $migrationContent)
+            file_put_contents(database_path('migrations').$migration, $migrationContent);
+        }
         $this->info('Migrating the database tables into your application');
         $this->call('migrate');
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -71,7 +71,8 @@ class InstallCommand extends Command
         $migrationsDirectory = scandir($basePath . '/publishable/database/migrations/');
         foreach($migrationsDirectory as $migration){
             $migrationContent = file_get_contents(database_path('migrations').$migration);
-            $migrationContent = str_replace('{*users_table*}', app(config('voyager.user')['namespace'])->getTable(), $migrationContent)
+            $migrationContent = str_replace('{*users_table*}', app(config('voyager.user')['namespace'])->getTable(), 
+                                            $migrationContent);
             file_put_contents(database_path('migrations').$migration, $migrationContent);
         }
         $this->info('Migrating the database tables into your application');

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -70,7 +70,11 @@ class InstallCommand extends Command
         $basePath = str_replace('/src/Commands', '', dirname(__DIR__.'/..'));
         $migrationsDirectory = scandir($basePath.'/publishable/database/migrations/');
         foreach($migrationsDirectory as $migration){
-            $migrationContent = file_get_contents(database_path('migrations').$migration);
+            if($migration === '.' || $migration === '..'){
+                continue;
+            }
+            $migrationPath = database_path('migrations').'/'.$migration;
+            $migrationContent = file_get_contents($migrationPath);
             $migrationContent = str_replace('{*users_table*}', app(config('voyager.user')['namespace'])->getTable(), 
                                             $migrationContent);
             file_put_contents(database_path('migrations').$migration, $migrationContent);

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -68,7 +68,7 @@ class InstallCommand extends Command
         */
         $this->info('Applying new user namespace table name');
         $basePath = dirname(__DIR__);
-        $migrationsDirectory = scandir($basePath . '/publishable/database/migrations/');
+        $migrationsDirectory = scandir('../publishable/database/migrations/');
         foreach($migrationsDirectory as $migration){
             $migrationContent = file_get_contents(database_path('migrations').$migration);
             $migrationContent = str_replace('{*users_table*}', app(config('voyager.user')['namespace'])->getTable(), 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -67,8 +67,8 @@ class InstallCommand extends Command
         * Translate migrations
         */
         $this->info('Applying new user namespace table name');
-        $basePath = dirname(__DIR__);
-        $migrationsDirectory = scandir('../publishable/database/migrations/');
+        $basePath = str_replace('/src', '', dirname(__DIR__.'/..'));
+        $migrationsDirectory = scandir($basePath.'/publishable/database/migrations/');
         foreach($migrationsDirectory as $migration){
             $migrationContent = file_get_contents(database_path('migrations').$migration);
             $migrationContent = str_replace('{*users_table*}', app(config('voyager.user')['namespace'])->getTable(), 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -69,16 +69,17 @@ class InstallCommand extends Command
         $this->info('Applying new user namespace table name');
         $basePath = str_replace('/src/Commands', '', dirname(__DIR__.'/..'));
         $migrationsDirectory = scandir($basePath.'/publishable/database/migrations/');
+        
         foreach($migrationsDirectory as $migration){
-            if($migration === '.' || $migration === '..'){
-                continue;
+            if($migration !== '.' && $migration !== '..'){
+                $migrationPath = database_path('migrations').'/'.$migration;
+                $migrationContent = file_get_contents($migrationPath);
+                $migrationContent = str_replace('{*users_table*}', "'".app(config('voyager.user')['namespace'])->getTable()."'", 
+                                                $migrationContent);
+                file_put_contents($migrationPath, $migrationContent);
             }
-            $migrationPath = database_path('migrations').'/'.$migration;
-            $migrationContent = file_get_contents($migrationPath);
-            $migrationContent = str_replace('{*users_table*}', app(config('voyager.user')['namespace'])->getTable(), 
-                                            $migrationContent);
-            file_put_contents(database_path('migrations').$migration, $migrationContent);
         }
+        
         $this->info('Migrating the database tables into your application');
         $this->call('migrate');
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -67,7 +67,7 @@ class InstallCommand extends Command
         * Translate migrations
         */
         $this->info('Applying new user namespace table name');
-        $basePath = str_replace('/src/Commands', '', dirname(__DIR__));
+        $basePath = str_replace('/src/Commands', '', dirname(__DIR__.'/..'));
         $migrationsDirectory = scandir($basePath.'/publishable/database/migrations/');
         foreach($migrationsDirectory as $migration){
             $migrationContent = file_get_contents(database_path('migrations').$migration);

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -67,7 +67,7 @@ class InstallCommand extends Command
         * Translate migrations
         */
         $this->info('Applying new user namespace table name');
-        $basePath = str_replace('/src', '', dirname(__DIR__.'/..'));
+        $basePath = str_replace('/src/Commands', '', dirname(__DIR__));
         $migrationsDirectory = scandir($basePath.'/publishable/database/migrations/');
         foreach($migrationsDirectory as $migration){
             $migrationContent = file_get_contents(database_path('migrations').$migration);


### PR DESCRIPTION
In my case my not only the User model is different, also the database name is different.

That's why I made this changes in order use the table name based on the model.

That means that you if you publish you vendors and then edit the namespace the migrations will take this user to resolve the user's table name