### PR TITLE
Refactoring permission helpers

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -30,7 +30,7 @@ class VoyagerBreadController extends Controller
         $dataType = DataType::where('slug', '=', $slug)->first();
 
         // Check permission
-        Voyager::can('browse_'.$dataType->name);
+        Voyager::canOrFail('browse_'.$dataType->name);
 
         $getter = $dataType->server_side ? 'paginate' : 'get';
 
@@ -76,7 +76,7 @@ class VoyagerBreadController extends Controller
         $dataType = DataType::where('slug', '=', $slug)->first();
 
         // Check permission
-        Voyager::can('read_'.$dataType->name);
+        Voyager::canOrFail('read_'.$dataType->name);
 
         $dataTypeContent = (strlen($dataType->model_name) != 0)
             ? call_user_func([$dataType->model_name, 'findOrFail'], $id)
@@ -110,7 +110,7 @@ class VoyagerBreadController extends Controller
         $dataType = DataType::where('slug', '=', $slug)->first();
 
         // Check permission
-        Voyager::can('edit_'.$dataType->name);
+        Voyager::canOrFail('edit_'.$dataType->name);
 
         $dataTypeContent = (strlen($dataType->model_name) != 0)
             ? call_user_func([$dataType->model_name, 'findOrFail'], $id)
@@ -133,7 +133,7 @@ class VoyagerBreadController extends Controller
         $dataType = DataType::where('slug', '=', $slug)->first();
 
         // Check permission
-        Voyager::can('edit_'.$dataType->name);
+        Voyager::canOrFail('edit_'.$dataType->name);
 
         $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
         $this->insertUpdateData($request, $slug, $dataType->editRows, $data);
@@ -166,7 +166,7 @@ class VoyagerBreadController extends Controller
         $dataType = DataType::where('slug', '=', $slug)->first();
 
         // Check permission
-        Voyager::can('add_'.$dataType->name);
+        Voyager::canOrFail('add_'.$dataType->name);
 
         $view = 'voyager::bread.edit-add';
 
@@ -185,7 +185,7 @@ class VoyagerBreadController extends Controller
         $dataType = DataType::where('slug', '=', $slug)->first();
 
         // Check permission
-        Voyager::can('add_'.$dataType->name);
+        Voyager::canOrFail('add_'.$dataType->name);
 
         $data = new $dataType->model_name();
         $this->insertUpdateData($request, $slug, $dataType->addRows, $data);
@@ -217,7 +217,7 @@ class VoyagerBreadController extends Controller
         $dataType = DataType::where('slug', '=', $slug)->first();
 
         // Check permission
-        Voyager::can('delete_'.$dataType->name);
+        Voyager::canOrFail('delete_'.$dataType->name);
 
         $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
 

--- a/src/Http/Controllers/VoyagerDatabaseController.php
+++ b/src/Http/Controllers/VoyagerDatabaseController.php
@@ -22,21 +22,21 @@ class VoyagerDatabaseController extends Controller
 
     public function index()
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         return view('voyager::tools.database.index');
     }
 
     public function create()
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         return view('voyager::tools.database.edit-add');
     }
 
     public function store(Request $request)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         $tableName = $request->name;
 
@@ -88,7 +88,7 @@ class VoyagerDatabaseController extends Controller
 
     public function edit($table)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         $rows = $this->describeTable($table);
 
@@ -104,7 +104,7 @@ class VoyagerDatabaseController extends Controller
      */
     public function update(Request $request)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         $this->renameTable($request->original_name, $request->name);
         $this->renameColumns($request, $request->name);
@@ -123,7 +123,7 @@ class VoyagerDatabaseController extends Controller
 
     public function reorder_column(Request $request)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         if ($request->ajax()) {
             $table = $request->table;
@@ -142,14 +142,14 @@ class VoyagerDatabaseController extends Controller
 
     public function show($table)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         return response()->json($this->describeTable($table));
     }
 
     public function destroy($table)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         try {
             Schema::drop($table);
@@ -181,7 +181,7 @@ class VoyagerDatabaseController extends Controller
      */
     public function addBread(Request $request)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         $table = $request->input('table');
 
@@ -205,7 +205,7 @@ class VoyagerDatabaseController extends Controller
 
     public function storeBread(Request $request)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         $dataType = new DataType();
         $data = $dataType->updateDataType($request->all())
@@ -223,7 +223,7 @@ class VoyagerDatabaseController extends Controller
 
     public function addEditBread($id)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         return view(
             'voyager::tools.database.edit-add-bread', [
@@ -234,7 +234,7 @@ class VoyagerDatabaseController extends Controller
 
     public function updateBread(Request $request, $id)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         /** @var \TCG\Voyager\Models\DataType $dataType */
         $dataType = DataType::find($id);
@@ -253,7 +253,7 @@ class VoyagerDatabaseController extends Controller
 
     public function deleteBread($id)
     {
-        Voyager::can('browse_database');
+        Voyager::canOrFail('browse_database');
 
         /** @var \TCG\Voyager\Models\DataType $dataType */
         $dataType = DataType::find($id);

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -28,7 +28,7 @@ class VoyagerMediaController extends Controller
 
     public function index()
     {
-        Voyager::can('browse_media');
+        Voyager::canOrFail('browse_media');
 
         return view('voyager::media.index');
     }

--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -11,7 +11,7 @@ class VoyagerMenuController extends Controller
 {
     public function builder($id)
     {
-        Voyager::can('edit_menus');
+        Voyager::canOrFail('edit_menus');
 
         $menu = Menu::findOrFail($id);
 
@@ -20,7 +20,7 @@ class VoyagerMenuController extends Controller
 
     public function delete_menu($menu, $id)
     {
-        Voyager::can('delete_menus');
+        Voyager::canOrFail('delete_menus');
 
         $item = MenuItem::findOrFail($id);
 
@@ -36,7 +36,7 @@ class VoyagerMenuController extends Controller
 
     public function add_item(Request $request)
     {
-        Voyager::can('add_menus');
+        Voyager::canOrFail('add_menus');
 
         $data = $request->all();
         $data['order'] = 1;
@@ -61,7 +61,7 @@ class VoyagerMenuController extends Controller
 
     public function update_item(Request $request)
     {
-        Voyager::can('edit_menus');
+        Voyager::canOrFail('edit_menus');
 
         $id = $request->input('id');
         $data = $request->except(['id']);

--- a/src/Http/Controllers/VoyagerRoleController.php
+++ b/src/Http/Controllers/VoyagerRoleController.php
@@ -11,7 +11,7 @@ class VoyagerRoleController extends VoyagerBreadController
     // POST BR(E)AD
     public function update(Request $request, $id)
     {
-        Voyager::can('edit_roles');
+        Voyager::canOrFail('edit_roles');
 
         $slug = $this->getSlug($request);
 
@@ -33,7 +33,7 @@ class VoyagerRoleController extends VoyagerBreadController
     // POST BRE(A)D
     public function store(Request $request)
     {
-        Voyager::can('add_roles');
+        Voyager::canOrFail('add_roles');
 
         $slug = $this->getSlug($request);
 

--- a/src/Http/Controllers/VoyagerSettingsController.php
+++ b/src/Http/Controllers/VoyagerSettingsController.php
@@ -12,7 +12,7 @@ class VoyagerSettingsController extends Controller
     public function index()
     {
         // Check permission
-        Voyager::can('browse_settings');
+        Voyager::canOrFail('browse_settings');
 
         $settings = Setting::orderBy('order', 'ASC')->get();
 
@@ -22,7 +22,7 @@ class VoyagerSettingsController extends Controller
     public function store(Request $request)
     {
         // Check permission
-        Voyager::can('browse_settings');
+        Voyager::canOrFail('browse_settings');
 
         $lastSetting = Setting::orderBy('order', 'DESC')->first();
 
@@ -46,7 +46,7 @@ class VoyagerSettingsController extends Controller
     public function update(Request $request)
     {
         // Check permission
-        Voyager::can('visit_settings');
+        Voyager::canOrFail('visit_settings');
 
         $settings = Setting::all();
 
@@ -73,10 +73,10 @@ class VoyagerSettingsController extends Controller
 
     public function delete($id)
     {
-        Voyager::can('browse_settings');
+        Voyager::canOrFail('browse_settings');
 
         // Check permission
-        Voyager::can('visit_settings');
+        Voyager::canOrFail('visit_settings');
 
         Setting::destroy($id);
 
@@ -114,7 +114,7 @@ class VoyagerSettingsController extends Controller
     public function delete_value($id)
     {
         // Check permission
-        Voyager::can('browse_settings');
+        Voyager::canOrFail('browse_settings');
 
         $setting = Setting::find($id);
 

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -46,7 +46,7 @@ trait VoyagerUser
 
     public function hasPermissionOrFail($name)
     {
-        if (! $this->hasPermission($name)) {
+        if (!$this->hasPermission($name)) {
             throw new UnauthorizedHttpException(null);
         }
 
@@ -55,7 +55,7 @@ trait VoyagerUser
 
     public function hasPermissionOrAbort($name, $statusCode = 403)
     {
-        if (! $this->hasPermission($name)) {
+        if (!$this->hasPermission($name)) {
             return abort($statusCode);
         }
 

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -2,6 +2,7 @@
 
 namespace TCG\Voyager\Traits;
 
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use TCG\Voyager\Models\Role;
 
 /**
@@ -41,5 +42,23 @@ trait VoyagerUser
     public function hasPermission($name)
     {
         return in_array($name, $this->role->permissions->pluck('key')->toArray());
+    }
+
+    public function hasPermissionOrFail($name)
+    {
+        if (! $this->hasPermission($name)) {
+            throw new UnauthorizedHttpException(null);
+        }
+
+        return true;
+    }
+
+    public function hasPermissionOrAbort($name, $statusCode = 403)
+    {
+        if (! $this->hasPermission($name)) {
+            return abort($statusCode);
+        }
+
+        return true;
     }
 }

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -72,7 +72,7 @@ class Voyager
 
     public function canOrFail($permission)
     {
-        if (! $this->can($permission)) {
+        if (!$this->can($permission)) {
             throw new UnauthorizedHttpException(null);
         }
 
@@ -81,7 +81,7 @@ class Voyager
 
     public function canOrAbort($permission, $statusCode = 403)
     {
-        if (! $this->can($permission)) {
+        if (!$this->can($permission)) {
             return abort($statusCode);
         }
 

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -57,13 +57,35 @@ class Voyager
 
         if ($exist) {
             $user = User::find(Auth::id());
+
             if ($user == null) {
-                throw new UnauthorizedHttpException(null);
+                return false;
             }
+
             if (!$user->hasPermission($permission)) {
-                throw new UnauthorizedHttpException(null);
+                return false;
             }
         }
+
+        return true;
+    }
+
+    public function canOrFail($permission)
+    {
+        if (! $this->can($permission)) {
+            throw new UnauthorizedHttpException(null);
+        }
+
+        return true;
+    }
+
+    public function canOrAbort($permission, $statusCode = 403)
+    {
+        if (! $this->can($permission)) {
+            return abort($statusCode);
+        }
+
+        return true;
     }
 
     public function getVersion()


### PR DESCRIPTION
For `v0.11` the usage of permissions should be like this:

```
if (Voyager::can('permission')) {
    // accessed
}
Voyager::canOrFail('permission');
Voyager::canOrAbort('permission', 403);

if (auth()->user()->hasPermission('permission')) {
    // accessed
}
auth()->user()->hasPermissionOrFail('permission');
auth()->user()->hasPermissionOrAbort('permission', 403);
```