### PR TITLE
Add default value for relationship

### DIFF
--- a/resources/views/bread/edit-add.blade.php
+++ b/resources/views/bread/edit-add.blade.php
@@ -110,9 +110,12 @@
                                                     $relationshipOptions = $relationshipClass::all();
 
                                                     // Try to get default value for the relationship
-                                                    $defaultRelationshipMethod = 'default_'.$row->field;
-                                                    if (method_exists($dataType->model_name, $defaultRelationshipMethod)) {
-                                                        $default = call_user_func([$dataType->model_name, $defaultRelationshipMethod]);
+                                                    // when default is a callable function (ClassName@methodName)
+                                                    if ($default != NULL) {
+                                                        $comps = explode('@', $default);
+                                                        if (count($comps) == 2 && method_exists($comps[0], $comps[1])) {
+                                                            $default = call_user_func([$comps[0], $comps[1]]);
+                                                        }
                                                     }
                                                     ?>
                                                     <optgroup label="Relationship">


### PR DESCRIPTION
Imagine you have a website where you have many moderators who can add products in different categories. Depending on the user_id of moderators, you want that they should **by default**  add products to a specific category. Normally the moderators have to choose the correct category all the time. If we can set the default value of the category automatically depending on user_id of the moderators, it would be great.

I'm thinking of different approaches for this issue.
In this pull request, I've implemented one approach that I think, it could be simple and flexible enough for a quick win.
Basically, parallel to a method for relationship in the model class, you add another method with the same name prefixed with keyword `default`, which returns the default value for that relationship.

Example for the field `user_id` of a Feature Model
````
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use App\User;
use Illuminate\Support\Facades\Auth;

class Feature extends Model
{
    public function user_id()
    {
        return $this->belongsTo(User::class);
    }

    public static function default_user_id()
    {
        return Auth::user() ? Auth::user()->id : NULL;
    }
}
````

So depending which user is logged in, we have a different  default user_id in BREAD form
![screen shot 2017-01-14 at 19 48 26](https://cloud.githubusercontent.com/assets/478757/21957552/d168e228-da98-11e6-9b54-286f5efeffe5.png)

![screen shot 2017-01-14 at 19 48 40](https://cloud.githubusercontent.com/assets/478757/21957551/d16822b6-da98-11e6-99ec-5eeb866c7163.png)
