### PR TITLE
Set models name base on the singular name of the table

### DIFF
--- a/src/Http/Controllers/VoyagerDatabaseController.php
+++ b/src/Http/Controllers/VoyagerDatabaseController.php
@@ -49,7 +49,7 @@ class VoyagerDatabaseController extends Controller
 
             if (isset($request->create_model) && $request->create_model == 'on') {
                 $params = [
-                    'name' => ucfirst($tableName),
+                    'name' => ucfirst(Str::singular($tableName)),
                 ];
 
                 if (in_array('deleted_at', $request->input('field.*'))) {


### PR DESCRIPTION
Currently, when creating a new table using voyager database tools and enabling the option for creating a model. Voyager will create a class base on the table name. (families =>  App\Families).

When you create a bread. the UI default suggested value for the model name is the singular value  "App\Family" which causes a problem if the users just wanted to use the default values. 

Editing bread would thrown an error "Class App\Family does not exist"