### PR TITLE
Disable Exception Handling for RouteTest

### DIFF
--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -21,7 +21,7 @@ class RouteTest extends TestCase
     public function testGetRoutes()
     {
         $this->disableExceptionHandling();
-        
+
         $this->visit(route('voyager.login'));
         $this->type('admin@admin.com', 'email');
         $this->type('password', 'password');

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -20,6 +20,8 @@ class RouteTest extends TestCase
      */
     public function testGetRoutes()
     {
+        $this->disableExceptionHandling();
+        
         $this->visit(route('voyager.login'));
         $this->type('admin@admin.com', 'email');
         $this->type('password', 'password');


### PR DESCRIPTION
This will throw the exception instead of failing with status 500.
Easier to read errors on TravisCI.