### PR TITLE
Fix database table delete button not working properly

### DIFF
--- a/resources/views/tools/database/index.blade.php
+++ b/resources/views/tools/database/index.blade.php
@@ -206,8 +206,8 @@
         $(function () {
 
             $('.bread_actions').on('click', '.delete', function (e) {
-                id = $(e.target).data('id');
-                name = $(e.target).data('name');
+                id = $(this).data('id');
+                name = $(this).data('name');
 
                 $('#delete_builder_name').text(name);
                 $('#delete_builder_form')[0].action += '/' + id;
@@ -236,8 +236,8 @@
             });
 
             $('td.actions').on('click', '.delete_table', function (e) {
-                table = $(e.target).data('table');
-                if ($(e.target).hasClass('remove-bread-warning')) {
+                table = $(this).data('table');
+                if ($(this).hasClass('remove-bread-warning')) {
                     toastr.warning("Please make sure to remove the BREAD on this table before deleting the table.");
                 } else {
                     $('#delete_table_name').text(table);


### PR DESCRIPTION
Currently in Database index, when the table delete button is clicked, _event.target_ is used, which refers to the exact element that triggered the click event.
This results in an issue if you click on the trash icon on the delete button, _event.target_ will be set to the _\<i\>_ element, which is not what we want. We want the _\<a\>_ element which has information about the table. So we use _this_ instead of _event.target_.

Steps to reproduce the bug:
Click on the trash icon on delete button.