### PR TITLE
Prevent addition of Voyager::routes() more than once

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tcg/voyager",
+    "name": "itc/voyager",
     "description": "A Laravel Admin Package for The Control Group to make your life easier and steer your project in the right direction",
     "keywords": ["laravel", "admin", "panel"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "itc/voyager",
+    "name": "tcg/voyager",
     "description": "A Laravel Admin Package for The Control Group to make your life easier and steer your project in the right direction",
     "keywords": ["laravel", "admin", "panel"],
     "license": "MIT",

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -74,11 +74,7 @@ class InstallCommand extends Command
         $process = new Process($composer.' dump-autoload');
         $process->setWorkingDirectory(base_path())->run();
 
-        $this->info('Adding Voyager routes to routes/web.php');
-        $filesystem->append(
-            base_path('routes/web.php'),
-            "\n\nRoute::group(['prefix' => 'admin'], function () {\n    Voyager::routes();\n});\n"
-        );
+        $this->call('voyager:routes');
 
         $this->info('Seeding data into the database');
         $this->seed('VoyagerDatabaseSeeder');

--- a/src/Commands/InstallRoutesCommand.php
+++ b/src/Commands/InstallRoutesCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace TCG\Voyager\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputOption;
+
+class InstallRoutesCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'voyager:routes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install Voyager routes';
+
+    /**
+     * Execute the console command.
+     *
+     * @param \Illuminate\Filesystem\Filesystem $filesystem
+     *
+     * @return void
+     */
+    public function fire(Filesystem $filesystem)
+    {
+        $filepath = base_path('routes/web.php');
+        $contents = $filesystem->get($filepath);
+
+        if (!$this->routesAlreadyInstalled($contents))
+        {
+            $this->info('Adding Voyager routes to routes/web.php');
+            $filesystem->append(
+                $filepath,
+                "\n\nRoute::group(['prefix' => 'admin'], function () {\n    Voyager::routes();\n});\n"
+            );
+        }
+    }
+
+    /**
+     * @param string $contents - String contents of routes file
+     * @return boolean
+     */
+    private function routesAlreadyInstalled($contents)
+    {
+        foreach (explode("\n", $contents) as $line) {
+            if (strpos($line, 'Voyager::routes()') !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/Commands/InstallRoutesCommand.php
+++ b/src/Commands/InstallRoutesCommand.php
@@ -4,7 +4,6 @@ namespace TCG\Voyager\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Input\InputOption;
 
 class InstallRoutesCommand extends Command
 {
@@ -45,6 +44,7 @@ class InstallRoutesCommand extends Command
 
     /**
      * @param string $contents - String contents of routes file
+     *
      * @return bool
      */
     private function routesAlreadyInstalled($contents)

--- a/src/Commands/InstallRoutesCommand.php
+++ b/src/Commands/InstallRoutesCommand.php
@@ -51,5 +51,4 @@ class InstallRoutesCommand extends Command
     {
         return (bool) preg_match('/Voyager::routes/m', $contents);
     }
-
 }

--- a/src/Commands/InstallRoutesCommand.php
+++ b/src/Commands/InstallRoutesCommand.php
@@ -34,8 +34,7 @@ class InstallRoutesCommand extends Command
         $filepath = base_path('routes/web.php');
         $contents = $filesystem->get($filepath);
 
-        if (!$this->routesAlreadyInstalled($contents))
-        {
+        if (!$this->routesAlreadyInstalled($contents)) {
             $this->info('Adding Voyager routes to routes/web.php');
             $filesystem->append(
                 $filepath,
@@ -46,7 +45,7 @@ class InstallRoutesCommand extends Command
 
     /**
      * @param string $contents - String contents of routes file
-     * @return boolean
+     * @return bool
      */
     private function routesAlreadyInstalled($contents)
     {

--- a/src/Commands/InstallRoutesCommand.php
+++ b/src/Commands/InstallRoutesCommand.php
@@ -50,12 +50,7 @@ class InstallRoutesCommand extends Command
      */
     private function routesAlreadyInstalled($contents)
     {
-        foreach (explode("\n", $contents) as $line) {
-            if (strpos($line, 'Voyager::routes()') !== false) {
-                return true;
-            }
-        }
-        return false;
+        return (bool) preg_match('/Voyager::routes/m', $contents);
     }
 
 }

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -183,6 +183,7 @@ class VoyagerServiceProvider extends ServiceProvider
         $this->commands(Commands\InstallCommand::class);
         $this->commands(Commands\ControllersCommand::class);
         $this->commands(Commands\AdminCommand::class);
+        $this->commands(Commands\InstallRoutesCommand::class);
     }
 
     /**


### PR DESCRIPTION
- Add InstallRoutesCommand (`artisan voyager:routes`)
- Addition of `Voyager::routes` to the routes file is now idempotent
- InstallCommand now delegates route installation to InstallRoutesCommand
