### PR TITLE
Added missing sortBy with custom menu view

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -174,7 +174,7 @@ class Menu extends Model
     public static function buildCustomOutput($menuItems, $view, $options, Request $request)
     {
         return view()->exists($view) ? view($view)
-            ->with('items', $menuItems)->render() : self::buildOutput($menuItems, '', $options, $request);
+            ->with('items', $menuItems->sortBy('order'))->render() : self::buildOutput($menuItems, '', $options, $request);
     }
 
     /**


### PR DESCRIPTION
With commit e1c44c9e2d7bc02d5e4d453a536e79966b6b4186 in `src/Models/Menu.php:48` the following code was replaces by an event: `$menuItems = $menuItems->items->sortBy('order');`

This caused the menu items to not be sorted when you are currently using a custom view. The methods `buildAdminOutput`, `buildAdminMenuOutput`, `buildBootstrapOutput`, `buildOutput` all implement the sortBy method except the `buildCustomOutput`.

I've added the sortBy method at the menu items collection so the menu items are now properly sorted.
