### PR TITLE
Multiple additions and improvements.

### DIFF
--- a/publishable/assets/js/app.js
+++ b/publishable/assets/js/app.js
@@ -2,6 +2,8 @@ $(document).ready(function(){
 
   $('#voyager-loader').fadeOut();
   $('.readmore').readmore({
+    collapsedHeight: 60,
+    embedCSS: true,
     lessLink: '<a href="#" class="readm-link">Read Less</a>',
     moreLink: '<a href="#" class="readm-link">Read More</a>',
   });
@@ -66,4 +68,5 @@ $(document).ready(function(){
   $('.navbar-right-expand-toggle').on('click', function(){
     $('ul.navbar-right').toggleClass('expanded');
   }); 
+  
 });

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -35,6 +35,22 @@
                                             @if($row->type == 'image')
                                                 <img src="@if( strpos($data->{$row->field}, 'http://') === false && strpos($data->{$row->field}, 'https://') === false){{ Voyager::image( $data->{$row->field} ) }}@else{{ $data->{$row->field} }}@endif" style="width:100px">
                                             @elseif($row->type == 'select_multiple')
+                                                @if(property_exists($options, 'relationship'))
+
+                                                    @foreach($data->{$row->field} as $item)
+                                                        @if($item->{$row->field . '_page_slug'})
+                                                        <a href="{{ $item->{$row->field . '_page_slug'} }}">{{ $item->{$row->field}  }}</a>@if(!$loop->last), @endif
+                                                        @else
+                                                        {{ $item->{$row->field}  }}
+                                                        @endif
+                                                    @endforeach
+
+                                                    {{-- $data->{$row->field}->implode($options->relationship->label, ', ') --}}
+                                                @elseif(property_exists($options, 'options'))
+                                                    @foreach($data->{$row->field} as $item)
+                                                     {{ $options->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                                    @endforeach
+                                                @endif
                                                 @if ($data->{$row->field} && isset($options->relationship))
                                                     {{ $data->{$row->field}->implode($options->relationship->label, ', ') }}
                                                 @endif
@@ -52,6 +68,12 @@
                                                 @else
                                                 {{ $data->{$row->field} }}
                                                 @endif
+                                            @elseif($row->type == 'text')
+                                            <div class="readmore">{{ $data->{$row->field} }}</div>
+                                            @elseif($row->type == 'text_area')
+                                            <div class="readmore">{{ $data->{$row->field} }}</div>                                            
+                                            @elseif($row->type == 'rich_text_box')
+                                            <div class="readmore">{{ $data->{$row->field} }}</div>
                                             @else
                                                 {{ $data->{$row->field} }}
                                             @endif

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -38,6 +38,22 @@
                                      src="{{ Voyager::image($dataTypeContent->{$row->field}) }}">
                             @elseif($row->type == 'select_dropdown' && $dataTypeContent->{$row->field . '_page_slug'})
                                 <a href="{{ $dataTypeContent->{$row->field . '_page_slug'} }}">{{ $dataTypeContent->{$row->field}  }}</a>
+                            @elseif($row->type == 'select_multiple')
+                                @if(property_exists($rowDetails, 'relationship'))
+
+                                    @foreach($dataTypeContent->{$row->field} as $item)
+                                        @if($item->{$row->field . '_page_slug'})
+                                        <a href="{{ $item->{$row->field . '_page_slug'} }}">{{ $item->{$row->field}  }}</a>@if(!$loop->last), @endif
+                                        @else
+                                        {{ $item->{$row->field}  }}
+                                        @endif
+                                    @endforeach
+
+                                @elseif(property_exists($rowDetails, 'options'))
+                                    @foreach($dataTypeContent->{$row->field} as $item)
+                                     {{ $rowDetails->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                    @endforeach
+                                @endif
                             @elseif($row->type == 'date')
                                 {{ $rowDetails && property_exists($rowDetails, 'format') ? \Carbon\Carbon::parse($dataTypeContent->{$row->field})->formatLocalized($rowDetails->format) : $dataTypeContent->{$row->field} }}
                             @elseif($row->type == 'checkbox')

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -40,7 +40,11 @@ abstract class Controller extends BaseController
 
             if (isset($options->validation)) {
                 if (isset($options->validation->rule)) {
-                    $rules[$row->field] = $options->validation->rule;
+                    if (!is_array($options->validation->rule)) {
+                        $rules[$row->field] = explode('|', $options->validation->rule);
+                    } else {
+                        $rules[$row->field] = $options->validation->rule;
+                    }
                 }
 
                 if (isset($options->validation->messages)) {
@@ -62,8 +66,10 @@ abstract class Controller extends BaseController
                 }
             }
 
-            if ($row->type == 'select_multiple') {
-                array_push($multi_select, ['row' => $row->field, 'content' => $content]);
+            if ($row->type == 'select_multiple' && property_exists($options, 'relationship')) {
+                // Only if select_multiple is working with a relationship
+                $multi_select[] = ['row' => $row->field, 'content' => $content];
+
             } else {
                 $data->{$row->field} = $content;
             }
@@ -122,31 +128,9 @@ abstract class Controller extends BaseController
             /********** SELECT MULTIPLE TYPE **********/
             case 'select_multiple':
                 $content = $request->input($row->field);
+
                 if ($content === null) {
                     $content = [];
-                } else {
-                    // Check if we need to parse the editablePivotFields to update fields in the corresponding pivot table
-                    $options = json_decode($row->details);
-                    if (isset($options->relationship) && !empty($options->relationship->editablePivotFields)) {
-                        $pivotContent = [];
-                        // Read all values for fields in pivot tables from the request
-                        foreach ($options->relationship->editablePivotFields as $pivotField) {
-                            if (!isset($pivotContent[$pivotField])) {
-                                $pivotContent[$pivotField] = [];
-                            }
-                            $pivotContent[$pivotField] = $request->input('pivot_'.$pivotField);
-                        }
-
-                        // Create a new content array for updating pivot table
-                        $newContent = [];
-                        foreach ($content as $contentIndex => $contentValue) {
-                            $newContent[$contentValue] = [];
-                            foreach ($pivotContent as $pivotContentKey => $value) {
-                                $newContent[$contentValue][$pivotContentKey] = $value[$contentIndex];
-                            }
-                        }
-                        $content = $newContent;
-                    }
                 }
 
                 return $content;

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -131,6 +131,28 @@ abstract class Controller extends BaseController
 
                 if ($content === null) {
                     $content = [];
+                } else {
+                    // Check if we need to parse the editablePivotFields to update fields in the corresponding pivot table
+                    $options = json_decode($row->details);
+                    if (isset($options->relationship) && !empty($options->relationship->editablePivotFields)) {
+                        $pivotContent = [];
+                        // Read all values for fields in pivot tables from the request
+                        foreach ($options->relationship->editablePivotFields as $pivotField) {
+                            if (!isset($pivotContent[$pivotField])) {
+                                $pivotContent[$pivotField] = [];
+                            }
+                            $pivotContent[$pivotField] = $request->input('pivot_'.$pivotField);
+                        }
+                        // Create a new content array for updating pivot table
+                        $newContent = [];
+                        foreach ($content as $contentIndex => $contentValue) {
+                            $newContent[$contentValue] = [];
+                            foreach ($pivotContent as $pivotContentKey => $value) {
+                                $newContent[$contentValue][$pivotContentKey] = $value[$contentIndex];
+                            }
+                        }
+                        $content = $newContent;
+                    }
                 }
 
                 return $content;

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -69,7 +69,6 @@ abstract class Controller extends BaseController
             if ($row->type == 'select_multiple' && property_exists($options, 'relationship')) {
                 // Only if select_multiple is working with a relationship
                 $multi_select[] = ['row' => $row->field, 'content' => $content];
-
             } else {
                 $data->{$row->field} = $content;
             }

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -10,10 +10,10 @@ trait BreadRelationshipParser
 {
     /**
      * Build the relationships array for the model's eager load.
-     * 
-     * @param  DataType $dataType 
-     * 
-     * @return Array
+     *
+     * @param DataType $dataType
+     *
+     * @return array
      */
     protected function getRelationships(DataType $dataType)
     {
@@ -35,10 +35,10 @@ trait BreadRelationshipParser
 
     /**
      * Replace relationships' keys for labels and create READ links if a slug is provided.
-     * 
+     *
      * @param  $dataTypeContent     Can be either an eloquent Model, Collection or LengthAwarePaginator instance.
-     * @param  DataType $dataType
-     * 
+     * @param DataType $dataType
+     *
      * @return $dataTypeContent
      */
     protected function resolveRelations($dataTypeContent, DataType $dataType)
@@ -65,18 +65,18 @@ trait BreadRelationshipParser
     }
 
     /**
-     * Create the URL for relationship's anchors in BROWSE and READ views
-     * 
-     * @param  Model    $item       Object to modify
-     * @param  DataType $dataType  
-     *  
-     * @return Model    $item
+     * Create the URL for relationship's anchors in BROWSE and READ views.
+     *
+     * @param Model    $item     Object to modify
+     * @param DataType $dataType
+     *
+     * @return Model $item
      */
     protected function relationToLink(Model $item, DataType $dataType)
     {
         $relations = $item->getRelations();
         // If there are not-null relations
-        if (! empty($relations) && array_filter($relations)) {
+        if (!empty($relations) && array_filter($relations)) {
             foreach ($relations as $field => $relation) {
                 $field = snake_case($field);
                 $bread_data = $dataType->browseRows->where('field', $field)->first();

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -49,7 +49,6 @@ trait BreadRelationshipParser
         }
         // If it's a model just make the changes directly on it (READ / EDIT)
         elseif ($dataTypeContent instanceof Model) {
-
             return $this->relationToLink($dataTypeContent, $dataType);
         }
         // Or we assume it's a Collection
@@ -86,7 +85,6 @@ trait BreadRelationshipParser
                 if (isset($relationData->page_slug)) {
                     $item[$field.'_page_slug'] = url($relationData->page_slug, $id);
                 }
-
             }
         }
 

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -90,6 +90,6 @@ trait BreadRelationshipParser
             }
         }
 
-        return $item;        
+        return $item;
     }
 }

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -17,7 +17,7 @@ trait BreadRelationshipParser
      */
     protected function getRelationships(DataType $dataType)
     {
-        $relationships = array();
+        $relationships = [];
 
         $dataType->browseRows->each(function ($item) use (&$relationships) {
             $details = json_decode($item->details);

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -48,7 +48,7 @@ trait BreadRelationshipParser
             $dataTypeCollection = $dataTypeContent->getCollection();
         }
         // If it's a model just make the changes directly on it (READ / EDIT)
-        else if ($dataTypeContent instanceof Model) {
+        elseif ($dataTypeContent instanceof Model) {
 
             return $this->relationToLink($dataTypeContent, $dataType);
         }
@@ -90,7 +90,6 @@ trait BreadRelationshipParser
             }
         }
 
-        return $item;
-        
+        return $item;        
     }
 }

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -10,14 +10,14 @@ trait BreadRelationshipParser
 {
     /**
      * Build the relationships array for the model's eager load.
-     *
-     * @param DataType $dataType
-     *
-     * @return array
+     * 
+     * @param  DataType $dataType 
+     * 
+     * @return Array
      */
     protected function getRelationships(DataType $dataType)
     {
-        $relationships = [];
+        $relationships = array();
 
         $dataType->browseRows->each(function ($item) use (&$relationships) {
             $details = json_decode($item->details);
@@ -35,20 +35,21 @@ trait BreadRelationshipParser
 
     /**
      * Replace relationships' keys for labels and create READ links if a slug is provided.
-     *
+     * 
      * @param  $dataTypeContent     Can be either an eloquent Model, Collection or LengthAwarePaginator instance.
-     * @param DataType $dataType
-     *
+     * @param  DataType $dataType
+     * 
      * @return $dataTypeContent
      */
-    protected function resolveRelations($dataTypeContent, DataType $dataType)
+    protected function resolveRelations($dataTypeContent, DataType $dataType, bool $isModel = false)
     {
         // In case of using server-side pagination, we need to work on the Collection (BROWSE)
         if ($dataTypeContent instanceof LengthAwarePaginator) {
             $dataTypeCollection = $dataTypeContent->getCollection();
         }
         // If it's a model just make the changes directly on it (READ / EDIT)
-        elseif ($dataTypeContent instanceof Model) {
+        else if ($dataTypeContent instanceof Model) {
+
             return $this->relationToLink($dataTypeContent, $dataType);
         }
         // Or we assume it's a Collection
@@ -64,18 +65,18 @@ trait BreadRelationshipParser
     }
 
     /**
-     * Create the URL for relationship's anchors in BROWSE and READ views.
-     *
-     * @param Model    $item     Object to modify
-     * @param DataType $dataType
-     *
-     * @return Model $item
+     * Create the URL for relationship's anchors in BROWSE and READ views
+     * 
+     * @param  Model    $item       Object to modify
+     * @param  DataType $dataType  
+     *  
+     * @return Model    $item
      */
     protected function relationToLink(Model $item, DataType $dataType)
     {
         $relations = $item->getRelations();
         // If there are not-null relations
-        if (!empty($relations) && array_filter($relations)) {
+        if (! empty($relations) && array_filter($relations)) {
             foreach ($relations as $field => $relation) {
                 $field = snake_case($field);
                 $bread_data = $dataType->browseRows->where('field', $field)->first();
@@ -85,9 +86,11 @@ trait BreadRelationshipParser
                 if (isset($relationData->page_slug)) {
                     $item[$field.'_page_slug'] = url($relationData->page_slug, $id);
                 }
+
             }
         }
 
         return $item;
+        
     }
 }

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -41,7 +41,7 @@ trait BreadRelationshipParser
      * 
      * @return $dataTypeContent
      */
-    protected function resolveRelations($dataTypeContent, DataType $dataType, bool $isModel = false)
+    protected function resolveRelations($dataTypeContent, DataType $dataType)
     {
         // In case of using server-side pagination, we need to work on the Collection (BROWSE)
         if ($dataTypeContent instanceof LengthAwarePaginator) {

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -153,6 +153,7 @@ class VoyagerBreadController extends Controller
         Voyager::can('edit_'.$dataType->name);
 
         $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
+
         $this->insertUpdateData($request, $slug, $dataType->editRows, $data);
 
         return redirect()


### PR DESCRIPTION
- [x] Make use of [readmore](https://i.gyazo.com/034e420277ddb8a74b945c64c8d4f477.png) library (was unused until now) for `text`, `text_area` and `rich_text_box` input types in BROWSE views.
- [x] * Allow `select_multiple` input type to simply [work like a `select_dropdown`](https://i.gyazo.com/5ee31264726e89fd8b031bc2c8da7c5c.png) (with `options` instead of `relationships`) with `JSON` columns.
- [x] Properly display of `select_multiple` rows for both `relationships` and simple `options` in [READ and BROWSE](https://i.gyazo.com/fc816559b833e1c18191ac3ccb1ab734.png) views
- [x] * Added support for `description` property in each BREAD row's `details` section, [to display it below each input](https://i.gyazo.com/c4970c93849e4e68410e61b93418cbdd.png).
- [x] Implemented logic to make use of `checkbox`es `checked` property when creating and editing
- [x] * Modified `validation` logic for BREAD rows so it can be setup either as a string like `"rules": "required|max:80"`, or an array:
```
{
    "validation" {
        "rules": [
            "required",
            "max:80"
        ]
    }
}
```
and if its a string, convert it to array, so you don't have any problem when using complex `regex` rules.


My apologizes for the spanish demos :laughing: 

--  * These changes should be documented, along with the changes in #638 regarding to `date`'s `format` property