### PR TITLE
Enchantment/menu route

### DIFF
--- a/publishable/database/migrations/2017_01_13_000000_add_route_to_menu_items_table.php
+++ b/publishable/database/migrations/2017_01_13_000000_add_route_to_menu_items_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddRouteToMenuItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->string('route')->nullable()->default(null);
+            $table->text('parameters')->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->dropColumn('route');
+            $table->dropColumn('parameters');
+        });
+    }
+}

--- a/publishable/database/migrations/2017_01_13_000000_add_route_to_menu_items_table.php
+++ b/publishable/database/migrations/2017_01_13_000000_add_route_to_menu_items_table.php
@@ -15,7 +15,7 @@ class AddRouteToMenuItemsTable extends Migration
     {
         Schema::table('menu_items', function (Blueprint $table) {
             $table->string('route')->nullable()->default(null);
-            $table->text('parameters');
+            $table->text('parameters')->nullable()->default(null);
         });
     }
 

--- a/publishable/database/migrations/2017_01_13_000000_add_route_to_menu_items_table.php
+++ b/publishable/database/migrations/2017_01_13_000000_add_route_to_menu_items_table.php
@@ -15,7 +15,7 @@ class AddRouteToMenuItemsTable extends Migration
     {
         Schema::table('menu_items', function (Blueprint $table) {
             $table->string('route')->nullable()->default(null);
-            $table->text('parameters')->default(null);
+            $table->text('parameters');
         });
     }
 

--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -119,8 +119,21 @@
                     <div class="modal-body">
                         <label for="name">Title of the Menu Item</label>
                         <input type="text" class="form-control" id="edit_title" name="title" placeholder="Title"><br>
-                        <label for="url">URL for the Menu Item</label>
-                        <input type="text" class="form-control" id="edit_url" name="url" placeholder="URL"><br>
+                        <label for="type">Link type</label>
+                        <select id="edit_type" class="form-control" name="type">
+                            <option value="url" selected="selected">Static URL</option>
+                            <option value="route">Dynamic Route</option>
+                        </select><br>
+                        <div id="url_type">
+                            <label for="url">URL for the Menu Item</label>
+                            <input type="text" class="form-control" id="edit_url" name="url" placeholder="URL"><br>
+                        </div>
+                        <div id="route_type">
+                            <label for="route">Route for the menu item</label>
+                            <input type="text" class="form-control" id="edit_route" name="route" placeholder="Route"><br>
+                            <label for="parameters">Route parameters (if any)</label>
+                            <textarea rows="3" class="form-control" id="edit_parameters" name="parameters" placeholder="{{ json_encode(['key' => 'value'], JSON_PRETTY_PRINT) }}"></textarea><br>
+                        </div>
                         <label for="icon_class">Font Icon class for the Menu Item (Use a <a
                                     href="{{ config('voyager.assets_path') . '/fonts/voyager/icons-reference.html' }}"
                                     target="_blank">Voyager Font Class</a>)</label>
@@ -167,6 +180,8 @@
                 $('#edit_url').val($(e.currentTarget).data('url'));
                 $('#edit_icon_class').val($(e.currentTarget).data('icon_class'));
                 $('#edit_color').val($(e.currentTarget).data('color'));
+                $('#edit_route').val($(e.currentTarget).data('route'));
+                $('#edit_parameters').val(JSON.stringify($(e.currentTarget).data('parameters')));
                 $('#edit_id').val(id);
 
                 if ($(e.currentTarget).data('target') == '_self') {
@@ -176,6 +191,14 @@
                     $("#edit_target option[value='_blank']").attr('selected', 'selected');
                     $("#edit_target").val('_blank');
                 }
+
+                if ($(e.currentTarget).data('route') != "") {
+                    $("#edit_type").val('route').change();
+                    $("#url_type").hide();
+                } else {
+                    $("#route_type").hide();
+                }
+
                 $('#edit_modal').modal('show');
             });
 
@@ -191,6 +214,16 @@
                     toastr.success("Successfully updated menu order.");
                 });
 
+            });
+
+            $('#edit_type').on('change', function (e) {
+                if ($("#edit_type").val() == 'route') {
+                    $("#url_type").hide();
+                    $("#route_type").show();
+                } else {
+                    $("#routel_type").hide();
+                    $("#url_type").show();
+                }
             });
 
         });

--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -107,11 +107,11 @@ class VoyagerMenuController extends Controller
     {
         switch ($parameters['type']) {
             case 'route':
-                $data['url'] = null;
+                $parameters['url'] = null;
                 break;
             case 'url':
-                $data['route'] = null;
-                $data['parameters'] = null;
+                $parameters['route'] = null;
+                $parameters['parameters'] = '';
                 break;
         }
 

--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -38,7 +38,10 @@ class VoyagerMenuController extends Controller
     {
         Voyager::canOrFail('add_menus');
 
-        $data = $request->all();
+        $data = $this->prepareParameters(
+            $request->all()
+        );
+
         $data['order'] = 1;
 
         $highestOrderMenuItem = MenuItem::where('parent_id', '=', null)
@@ -64,7 +67,9 @@ class VoyagerMenuController extends Controller
         Voyager::canOrFail('edit_menus');
 
         $id = $request->input('id');
-        $data = $request->except(['id']);
+        $data = $this->prepareParameters(
+            $request->except(['id'])
+        );
 
         $menuItem = MenuItem::findOrFail($id);
         $menuItem->update($data);
@@ -96,5 +101,22 @@ class VoyagerMenuController extends Controller
                 $this->orderMenu($menuItem->children, $item->id);
             }
         }
+    }
+
+    protected function prepareParameters($parameters)
+    {
+        switch ($parameters['type']) {
+            case 'route':
+                $data['url'] = null;
+                break;
+            case 'url':
+                $data['route'] = null;
+                $data['parameters'] = null;
+                break;
+        }
+
+        unset($parameters['type']);
+
+        return $parameters;
     }
 }

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -385,7 +385,7 @@ class Menu extends Model
             $output .= '<li class="dd-item" data-id="'.$item->id.'">';
             $output .= '<div class="pull-right item_actions">';
             $output .= '<div class="btn-sm btn-danger pull-right delete" data-id="'.$item->id.'"><i class="voyager-trash"></i> Delete</div>';
-            $output .= '<div class="btn-sm btn-primary pull-right edit" data-id="'.$item->id.'" data-title="'.$item->title.'" data-url="'.$item->url.'" data-target="'.$item->target.'" data-icon_class="'.$item->icon_class.'" data-color="'.$item->color.'"><i class="voyager-edit"></i> Edit</div>';
+            $output .= '<div class="btn-sm btn-primary pull-right edit" data-id="'.$item->id.'" data-title="'.$item->title.'" data-url="'.$item->url.'" data-target="'.$item->target.'" data-icon_class="'.$item->icon_class.'" data-color="'.$item->color.'" data-route="'.$item->route.'" data-parameters="'.htmlspecialchars(json_encode($item->parameters)).'"><i class="voyager-edit"></i> Edit</div>';
             $output .= '</div>';
             $output .= '<div class="dd-handle">'.$item->title.' <small class="url">'.$item->url.'</small></div>';
 

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -387,7 +387,7 @@ class Menu extends Model
             $output .= '<div class="btn-sm btn-danger pull-right delete" data-id="'.$item->id.'"><i class="voyager-trash"></i> Delete</div>';
             $output .= '<div class="btn-sm btn-primary pull-right edit" data-id="'.$item->id.'" data-title="'.$item->title.'" data-url="'.$item->url.'" data-target="'.$item->target.'" data-icon_class="'.$item->icon_class.'" data-color="'.$item->color.'" data-route="'.$item->route.'" data-parameters="'.htmlspecialchars(json_encode($item->parameters)).'"><i class="voyager-edit"></i> Edit</div>';
             $output .= '</div>';
-            $output .= '<div class="dd-handle">'.$item->title.' <small class="url">'.$item->url.'</small></div>';
+            $output .= '<div class="dd-handle">'.$item->title.' <small class="url">'.$item->link().'</small></div>';
 
             $children_menu_items = $menuItems->filter(function ($value, $key) use ($item) {
                 return $value->parent_id == $item->id;

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -9,4 +9,31 @@ class MenuItem extends Model
     protected $table = 'menu_items';
 
     protected $guarded = [];
+
+    public function link($absolute = false)
+    {
+        if (! is_null($this->route)) {
+            return route($this->route, $this->getParametersAttribute(), $absolute);
+        }
+
+        if ($absolute) {
+            return url($this->url);
+        }
+
+        return $this->url;
+    }
+
+    public function getParametersAttribute()
+    {
+        return json_decode($this->attributes['parameters']);
+    }
+
+    public function setParametersAttribute($value)
+    {
+        if (is_array($value)) {
+            $value = json_encode($value);
+        }
+        
+        $this->attributes['parameters'] = $value;
+    }
 }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Route;
 
 class MenuItem extends Model
 {
@@ -13,7 +14,13 @@ class MenuItem extends Model
     public function link($absolute = false)
     {
         if (! is_null($this->route)) {
-            return route($this->route, $this->getParametersAttribute(), $absolute);
+            if (! Route::has($this->route)) {
+                return '#';
+            }
+
+            $parameters = (array) $this->getParametersAttribute();
+
+            return route($this->route, $parameters, $absolute);
         }
 
         if ($absolute) {
@@ -33,7 +40,7 @@ class MenuItem extends Model
         if (is_array($value)) {
             $value = json_encode($value);
         }
-        
+
         $this->attributes['parameters'] = $value;
     }
 }

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -13,8 +13,8 @@ class MenuItem extends Model
 
     public function link($absolute = false)
     {
-        if (! is_null($this->route)) {
-            if (! Route::has($this->route)) {
+        if (!is_null($this->route)) {
+            if (!Route::has($this->route)) {
                 return '#';
             }
 


### PR DESCRIPTION
Make menu urls enable to use route name and route parameters over the raw url.

The `menu_items` table does now have the `route` and `parameters` column.
And the MenuItem model now have a helper method `link` that will generate the correct link according to whether or not row uses fixed url or a route.
When editing a menu item, there is now also this option.

#### Dynamic Route
<img width="579" alt="skaermbillede 2017-02-13 kl 18 23 46" src="https://cloud.githubusercontent.com/assets/2232539/22894538/9bd96c84-f219-11e6-9845-6329e761e460.png">

#### Static URL
<img width="590" alt="skaermbillede 2017-02-13 kl 16 19 26" src="https://cloud.githubusercontent.com/assets/2232539/22889339/1359d610-f209-11e6-8bac-ce5b8d815b2a.png">