### PR TITLE
Drop columns only if exists

### DIFF
--- a/src/Http/Controllers/Traits/DatabaseUpdate.php
+++ b/src/Http/Controllers/Traits/DatabaseUpdate.php
@@ -75,15 +75,19 @@ trait DatabaseUpdate
      */
     private function dropColumns(Request $request, $tableName)
     {
+        $existingColumns = DBSchema::describeTable($tableName)->keyBy('field');
+
         if (isset($request->delete_field)) {
             foreach ($request->delete_field as $index => $delete) {
                 // If the column is set for destruction, then by all means, destroy it!
                 if ((bool) $delete) {
                     $columnName = $request->field[$index];
 
-                    Schema::table($tableName, function (Blueprint $table) use ($columnName) {
-                        $table->dropColumn($columnName);
-                    });
+                    if ($existingColumns->has($columnName)) {
+                        Schema::table($tableName, function (Blueprint $table) use ($columnName) {
+                            $table->dropColumn($columnName);
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
To avoid errors when try delete column not exists in database.