### PR TITLE
Adding the admin_logo_img as the main logo in the login screen

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -34,7 +34,7 @@
             <div class="clearfix">
                 <div class="col-sm-12 col-md-10 col-md-offset-2">
                     <div class="logo-title-container">
-                        <?php $admin_logo_img = Voyager::setting('logo', ''); ?>
+                        <?php $admin_logo_img = Voyager::setting('admin_logo_img', ''); ?>
                         @if($admin_logo_img == '')
                         <img class="img-responsive pull-left logo hidden-xs" src="{{ config('voyager.assets_path') }}/images/logo-icon-light.png" alt="Logo Icon">
                         @else


### PR DESCRIPTION
Adding the `admin_logo_img` to the login page instead of `logo`, the `logo` in the settings is going to be used for the front-end of the site, so when a user wants to add their logo on the front-end, they can call: `setting('logo')` and it will return the logo image.