### PR TITLE
Adding widgets to be registered to the config

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -86,39 +86,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Widgets Config
-    |--------------------------------------------------------------------------
-    |
-    | Here you can specify voyager administration settings
-    |
-    */
-
-    'widgets' => [
-        [
-            'name'  => 'User',
-            'icon'  => 'voyager-group',
-            'model' => TCG\Voyager\Models\User::class,
-            'url'   => 'admin/users',
-            'image' => '/images/widget-backgrounds/02.png',
-        ],
-        [
-            'name'  => 'Post',
-            'icon'  => 'voyager-news',
-            'model' => TCG\Voyager\Models\Post::class,
-            'url'   => 'admin/posts',
-            'image' => '/images/widget-backgrounds/03.png',
-        ],
-        [
-            'name'  => 'Page',
-            'icon'  => 'voyager-file-text',
-            'model' => TCG\Voyager\Models\Page::class,
-            'url'   => 'admin/pages',
-            'image' => '/images/widget-backgrounds/04.png',
-        ],
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Dashboard config
     |--------------------------------------------------------------------------
     |
@@ -147,10 +114,17 @@ return [
         'data_tables' => [
             'responsive' => true, // Use responsive extension for jQuery dataTables that are not server-side paginated
         ],
+        'widgets' => [
+            'TCG\\Voyager\\Widgets\\UserDimmer',
+            'TCG\\Voyager\\Widgets\\PostDimmer',
+            'TCG\\Voyager\\Widgets\\PageDimmer',
+        ],
     ],
+
     'login' => [
         'gradient_a' => '#ffffff',
         'gradient_b' => '#ffffff',
     ],
+
     'primary_color' => '#22A7F0',
 ];

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -167,12 +167,11 @@ class VoyagerServiceProvider extends ServiceProvider
      */
     protected function registerWidgets()
     {
-        $widgets = ['UserDimmer', 'PostDimmer', 'PageDimmer'];
+        $default_widgets = ['TCG\\Voyager\\Widgets\\UserDimmer', 'TCG\\Voyager\\Widgets\\PostDimmer', 'TCG\\Voyager\\Widgets\\PageDimmer'];
+        $widgets = config('voyager.dashboard.widgets', $default_widgets);
 
         foreach ($widgets as $widget) {
-            $class = 'TCG\\Voyager\\Widgets\\'.studly_case($widget);
-
-            Widget::group('voyager::dimmers')->addWidget($class);
+            Widget::group('voyager::dimmers')->addWidget($widget);
         }
     }
 


### PR DESCRIPTION
Adding the widgets to the config, by default the following widgets will be registered if that config is not set:

```$default_widgets = ['TCG\\Voyager\\Widgets\\UserDimmer', 'TCG\\Voyager\\Widgets\\PostDimmer', 'TCG\\Voyager\\Widgets\\PageDimmer'];```

Now, users can run `php artisan make:widget WidgetName` and register add that widget to the array of widgets to show on the dashboard.