### PR TITLE
Fix Mysql TIMESTAMP type not accepting NULL as a default value

### DIFF
--- a/src/Database/Types/Mysql/TimestampType.php
+++ b/src/Database/Types/Mysql/TimestampType.php
@@ -11,6 +11,8 @@ class TimestampType extends Type
 
     public function getSQLDeclaration(array $field, AbstractPlatform $platform)
     {
-        return 'timestamp';
+        $null = isset($field['default']) ? '' : ' null';
+
+        return 'timestamp'.$null;
     }
 }


### PR DESCRIPTION
Note: I will create a new PR to also handle CURRENT_TIMESTAMP issue.