### PR TITLE
Fix Mysql TimeStamp type not accepting null as a default value

### DIFF
--- a/src/Database/Types/Mysql/TimeStampType.php
+++ b/src/Database/Types/Mysql/TimeStampType.php
@@ -5,12 +5,16 @@ namespace TCG\Voyager\Database\Types\Mysql;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use TCG\Voyager\Database\Types\Type;
 
-class TimestampType extends Type
+class TimeStampType extends Type
 {
     const NAME = 'timestamp';
 
     public function getSQLDeclaration(array $field, AbstractPlatform $platform)
     {
-        return 'timestamp';
+        if (isset($field['default'])) {
+            return 'timestamp';
+        }
+
+        return 'timestamp null';
     }
 }


### PR DESCRIPTION
Note: There is also a problem with Timestamp if you set the default value to CURRENT_TIMESTAMP. This is a Doctrine DBAL issue, and it's been reported. I'll create a future PR when the issue is fixed.