### PR TITLE
Remove 'PRI' type from BREAD

### DIFF
--- a/publishable/database/seeds/DataRowsTableSeeder.php
+++ b/publishable/database/seeds/DataRowsTableSeeder.php
@@ -21,7 +21,7 @@ class DataRowsTableSeeder extends Seeder
         $dataRow = $this->dataRow($postDataType, 'id');
         if (!$dataRow->exists) {
             $dataRow->fill([
-                'type'         => 'PRI',
+                'type'         => 'number',
                 'display_name' => 'ID',
                 'required'     => 1,
                 'browse'       => 0,
@@ -240,7 +240,7 @@ class DataRowsTableSeeder extends Seeder
         $dataRow = $this->dataRow($pageDataType, 'id');
         if (!$dataRow->exists) {
             $dataRow->fill([
-                'type'         => 'PRI',
+                'type'         => 'number',
                 'display_name' => 'id',
                 'required'     => 1,
                 'browse'       => 0,
@@ -432,7 +432,7 @@ class DataRowsTableSeeder extends Seeder
         $dataRow = $this->dataRow($userDataType, 'id');
         if (!$dataRow->exists) {
             $dataRow->fill([
-                'type'         => 'PRI',
+                'type'         => 'number',
                 'display_name' => 'id',
                 'required'     => 1,
                 'browse'       => 0,
@@ -552,7 +552,7 @@ class DataRowsTableSeeder extends Seeder
         $dataRow = $this->dataRow($menuDataType, 'id');
         if (!$dataRow->exists) {
             $dataRow->fill([
-                'type'         => 'PRI',
+                'type'         => 'number',
                 'display_name' => 'id',
                 'required'     => 1,
                 'browse'       => 0,
@@ -612,7 +612,7 @@ class DataRowsTableSeeder extends Seeder
         $dataRow = $this->dataRow($categoryDataType, 'id');
         if (!$dataRow->exists) {
             $dataRow->fill([
-                'type'         => 'PRI',
+                'type'         => 'number',
                 'display_name' => 'id',
                 'required'     => 1,
                 'browse'       => 0,
@@ -731,7 +731,7 @@ class DataRowsTableSeeder extends Seeder
         $dataRow = $this->dataRow($roleDataType, 'id');
         if (!$dataRow->exists) {
             $dataRow->fill([
-                'type'         => 'PRI',
+                'type'         => 'number',
                 'display_name' => 'id',
                 'required'     => 1,
                 'browse'       => 0,

--- a/resources/views/tools/database/edit-add-bread.blade.php
+++ b/resources/views/tools/database/edit-add-bread.blade.php
@@ -95,10 +95,7 @@
                                     </td>
                                     <input type="hidden" name="field_{{ $data['field'] }}" value="{{ $data['field'] }}">
                                     <td>
-                                        @if($data['key'] == 'PRI')
-                                            <p>Primary Key</p>
-                                            <input type="hidden" value="PRI" name="field_input_type_{{ $data['field'] }}">
-                                        @elseif($data['type'] == 'timestamp')
+                                        @if($data['type'] == 'timestamp')
                                             <p>Timestamp</p>
                                             <input type="hidden" value="timestamp"
                                                    name="field_input_type_{{ $data['field'] }}">


### PR DESCRIPTION
Right now, `Primary key` columns by default are set to `'PRI'` type in BREAD.
I think the idea was that Primary columns were supposed to be `hidden` by default. This causes some issues. For example, if the user needed to store input in the Primary column, he couldn't do that.

With changes in this PR, it's now up to the user to decide if he wants to add BREAD for his Primary column, and he can choose any input type he likes.
Fix #821