### PR TITLE
Clean Data Rows when updating Data Type

### DIFF
--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -90,6 +90,11 @@ class DataType extends Model
                     }
                 }
 
+                // Clean data_rows that don't have an associated field
+                // TODO: need a way to identify deleted and renamed fields.
+                //   maybe warn the user and let him decide to either rename or delete?
+                $this->rows()->whereNotIn('field', $fields)->delete();
+
                 // It seems everything was fine. Let's check if we need to generate permissions
                 if ($this->generate_permissions) {
                     Voyager::model('Permission')->generateFor($this->name);


### PR DESCRIPTION
Currently `data_types` and `data_rows` are not in sync with the database. So any changes to the database will not affect them. For example, deleting or renaming fields can mess up BREAD.
Currently it's on my todo list to `sync` BREAD with database changes, however this will only be possible if Voyager's database manager is used. If the user makes changes to database outside Voyager, we need a way to to deal with that. Maybe warn the user and let him decide what to do (delete, rename, update data types and data rows etc...).

This PR kicks off the work regarding this issue.

Fix for #824 