### PR TITLE
Add prefilled id column when creating a new table

### DIFF
--- a/resources/views/tools/database/vue-components/database-table-editor.blade.php
+++ b/resources/views/tools/database/vue-components/database-table-editor.blade.php
@@ -46,11 +46,11 @@
                     <th>Name</th>
                     <th>Type</th>
                     <th>Length</th>
-                    <th>Not Null?</th>
-                    <th>Unsigned?</th>
-                    <th>AI?</th>
+                    <th>Not Null</th>
+                    <th>Unsigned</th>
+                    <th>Auto Increment</th>
                     <th>Index</th>
-                    <th>Default Value</th>
+                    <th>Default</th>
                     <th></th>
                 </tr>
                 </thead>

--- a/src/Http/Controllers/VoyagerDatabaseController.php
+++ b/src/Http/Controllers/VoyagerDatabaseController.php
@@ -138,6 +138,16 @@ class VoyagerDatabaseController extends Controller
             $db->formAction = route('voyager.database.update', $table);
         } else {
             $db->table = new Table('New Table');
+
+            // Add prefilled columns
+            $db->table->addColumn('id', 'integer', [
+                'unsigned'      => true,
+                'notnull'       => true,
+                'autoincrement' => true,
+            ]);
+
+            $db->table->setPrimaryKey(['id'], 'primary');
+
             $db->formAction = route('voyager.database.store');
         }
 


### PR DESCRIPTION
Since most tables will have an `id` column, now when creating a new table, it will have one prefilled to avoid adding it manually.