### PR TITLE
use intervention\image to orientate the uploaded media.

### DIFF
--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -5,9 +5,9 @@ namespace TCG\Voyager\Http\Controllers;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\ImageManagerStatic as Image;
 use TCG\Voyager\Facades\Voyager;
 
-use Intervention\Image\ImageManagerStatic as Image;
 
 class VoyagerMediaController extends Controller
 {
@@ -184,7 +184,7 @@ class VoyagerMediaController extends Controller
             $message = $e->getMessage();
         }
 
-        $realPath = Storage::disk($this->filesystem)->getDriver()->getAdapter()->getPathPrefix() . $path;
+        $realPath = Storage::disk($this->filesystem)->getDriver()->getAdapter()->getPathPrefix().$path;
         Image::make($realPath)->orientate()->save();
 
         $path = preg_replace('/^public\//', '', $path);

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Storage;
 use Intervention\Image\ImageManagerStatic as Image;
 use TCG\Voyager\Facades\Voyager;
 
-
 class VoyagerMediaController extends Controller
 {
     /** @var string */

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -7,6 +7,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use TCG\Voyager\Facades\Voyager;
 
+use Intervention\Image\ImageManagerStatic as Image;
+
 class VoyagerMediaController extends Controller
 {
     /** @var string */
@@ -181,6 +183,9 @@ class VoyagerMediaController extends Controller
             $success = false;
             $message = $e->getMessage();
         }
+
+        $realPath = Storage::disk($this->filesystem)->getDriver()->getAdapter()->getPathPrefix() . $path;
+        Image::make($realPath)->orientate()->save();
 
         $path = preg_replace('/^public\//', '', $path);
 


### PR DESCRIPTION
Most portrait oriented pictures are actually landscape pictures with an orientation in their exif data. 
So most browsers will display the pictures rotated by 90°. Fortunately you already requiring  the intervention / image composer library so we can easily use it to orientate the picture during the upload process.