### PR TITLE
Removing the unneccessary ace_editor for the options_editor since it …

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -309,7 +309,7 @@
                                 <small>(optional, only applies to certain types like dropdown box or radio button)
                                 </small>
                             </label>
-                            <div id="options_editor" class="form-control ace_editor min_height_200" data-language="json"></div>
+                            <div id="options_editor" class="form-control min_height_200" data-language="json"></div>
                             <textarea id="options_textarea" name="details" class="hidden"></textarea>
                             <div id="valid_options" class="alert-success alert" style="display:none">Valid Json</div>
                             <div id="invalid_options" class="alert-danger alert" style="display:none">Invalid Json</div>


### PR DESCRIPTION
Removing the .ace_editor class from the #options_editor, since it already is instantiated as an Ace Editor via the ID, it is getting re-instantiated by having the class .ace_editor.

Removing this class will make it work correctly.

@fletch3555 Sorry man, need a quick update, can you merge this in for me.

I'm simply removing a class that added in the previous commit 👍 