### PR TITLE
Disable database migration generation

### DIFF
--- a/resources/views/tools/database/vue-components/database-table-editor.blade.php
+++ b/resources/views/tools/database/vue-components/database-table-editor.blade.php
@@ -25,7 +25,7 @@
 
             <div class="col-md-3 col-sm-4 col-xs-6">
                 <label for="create_migration">Create migration for this table?</label><br>
-                <input type="checkbox" name="create_migration" data-toggle="toggle"
+                <input disabled type="checkbox" name="create_migration" data-toggle="toggle"
                        data-on="Yes, Please" data-off="No Thanks">
             </div>
         @endif


### PR DESCRIPTION
Generating migrations is not useful at the moment since it's only generating a stub.
Adding full migration generation is on my todo list. So until that is added, we should just disable this.