### PR TITLE
Added ability to provide a custom list for available options in dropdowns

### DIFF
--- a/resources/views/formfields/select_dropdown.blade.php
+++ b/resources/views/formfields/select_dropdown.blade.php
@@ -24,8 +24,13 @@
             @endif
             {{-- Populate all options from relationship --}}
             <?php
-            $relationshipClass = $dataTypeContent->{camel_case($row->field)}()->getRelated();
-            $relationshipOptions = $relationshipClass::all();
+            $relationshipListMethod = camel_case($row->field) . 'List';
+            if (method_exists($dataTypeContent, $relationshipListMethod)) {
+                $relationshipOptions = $dataTypeContent->$relationshipListMethod();
+            } else {
+                $relationshipClass = $dataTypeContent->{camel_case($row->field)}()->getRelated();
+                $relationshipOptions = $relationshipClass::all();
+            }
 
             // Try to get default value for the relationship
             // when default is a callable function (ClassName@methodName)

--- a/resources/views/formfields/select_multiple.blade.php
+++ b/resources/views/formfields/select_multiple.blade.php
@@ -8,8 +8,15 @@
         {{-- Check that the relationship method exists --}}
         @if( method_exists( $dataType->model_name, camel_case($row->field) ) )
             <?php $selected_values = isset($dataTypeContent) ? $dataTypeContent->{camel_case($row->field)}()->pluck($options->relationship->key)->all() : array(); ?>
-            <?php $relationshipClass = get_class(app($dataType->model_name)->{camel_case($row->field)}()->getRelated()); ?>
-            <?php $relationshipOptions = $relationshipClass::all(); ?>
+            <?php
+            $relationshipListMethod = camel_case($row->field) . 'List';
+            if (method_exists($dataTypeContent, $relationshipListMethod)) {
+                $relationshipOptions = $dataTypeContent->$relationshipListMethod();
+            } else {
+                $relationshipClass = get_class(app($dataType->model_name)->{camel_case($row->field)}()->getRelated());
+                $relationshipOptions = $relationshipClass::all();
+            }
+            ?>
             @foreach($relationshipOptions as $relationshipOption)
                 <option value="{{ $relationshipOption->{$options->relationship->key} }}" @if(in_array($relationshipOption->{$options->relationship->key}, $selected_values)){{ 'selected="selected"' }}@endif>{{ $relationshipOption->{$options->relationship->label} }}</option>
             @endforeach

--- a/resources/views/formfields/select_multiple.blade.php
+++ b/resources/views/formfields/select_multiple.blade.php
@@ -10,7 +10,7 @@
             <?php $selected_values = isset($dataTypeContent) ? $dataTypeContent->{camel_case($row->field)}()->pluck($options->relationship->key)->all() : array(); ?>
             <?php
             $relationshipListMethod = camel_case($row->field) . 'List';
-            if (method_exists($dataTypeContent, $relationshipListMethod)) {
+            if (isset($dataTypeContent) && method_exists($dataTypeContent, $relationshipListMethod)) {
                 $relationshipOptions = $dataTypeContent->$relationshipListMethod();
             } else {
                 $relationshipClass = get_class(app($dataType->model_name)->{camel_case($row->field)}()->getRelated());


### PR DESCRIPTION
I came across the case where I needed to limit the results displayed in the multiple dropdowns according to my current model instance.

I solved the problem by testing for a `$dataTypeContent->relationshipIdList()` method on the model responsible of providing the list of available results.

What are your thoughts?