### PR TITLE
Add method for Post to get image thumbnails

### DIFF
--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -52,4 +52,21 @@ class Post extends Model
     {
         return $this->hasOne(Voyager::modelClass('Category'), 'id', 'category_id');
     }
+
+    /**
+    *   
+    *   Method for returning specific thumbnail for post.
+    */
+
+    public function thumbnail($type) {
+        // We take image from posts field
+        $image  = $this->attributes['image'];
+        // We need to get extension type ( .jpeg , .png ...)
+        $ext    = pathinfo($image, PATHINFO_EXTENSION);
+        // We remove extension from file name so we can append thumbnail type
+        $name   = rtrim($image , '.'.$ext);
+        // We merge original name + type + extension
+        return $name . '-' . $type . '.' . $ext;
+    }
+
 }

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -56,15 +56,14 @@ class Post extends Model
     /**
     *   Method for returning specific thumbnail for post.
     */
-
-    public function thumbnail($type) 
+    public function thumbnail($type)
     {
         // We take image from posts field
         $image  = $this->attributes['image'];
         // We need to get extension type ( .jpeg , .png ...)
         $ext    = pathinfo($image, PATHINFO_EXTENSION);
         // We remove extension from file name so we can append thumbnail type
-        $name   = rtrim($image,'.'.$ext);
+        $name   = rtrim($image, '.'. $ext);
         // We merge original name + type + extension
         return $name . '-' . $type . '.' . $ext;
     }

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -54,19 +54,18 @@ class Post extends Model
     }
 
     /**
-    *   
     *   Method for returning specific thumbnail for post.
     */
 
-    public function thumbnail($type) {
+    public function thumbnail($type) 
+    {
         // We take image from posts field
         $image  = $this->attributes['image'];
         // We need to get extension type ( .jpeg , .png ...)
         $ext    = pathinfo($image, PATHINFO_EXTENSION);
         // We remove extension from file name so we can append thumbnail type
-        $name   = rtrim($image , '.'.$ext);
+        $name   = rtrim($image,'.'.$ext);
         // We merge original name + type + extension
         return $name . '-' . $type . '.' . $ext;
     }
-
 }


### PR DESCRIPTION
We have option in **Optional Details** to crop image in different sizes, and because image is saved in image field as full path I think we should have method if we need to get specific cropped version of image.

In Blade we can use **$post->image** to get full image path, but it is problem to get thumbnail versions of that image.

With this method we can get thumbnail version by using **$post->thumbnail('cropped')** to get cropped version of saved image.