### PR TITLE
bug fix

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -55,7 +55,7 @@ class VoyagerBreadController extends Controller
         }
 
         // Check if BREAD is Translatable
-        $isModelTranslatable = isBreadTranslatable($model);
+        $isModelTranslatable = isBreadTranslatable($dataTypeContent);
 
         $view = 'voyager::bread.browse';
 


### PR DESCRIPTION
should call isBreadTranslatable with $dataTypeContent variable, and not $model which might not be defined