### PR TITLE
Redirecting to intended URL after Login

### DIFF
--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -24,6 +24,12 @@ class VoyagerAdminMiddleware
             return $user->hasPermission('browse_admin') ? $next($request) : redirect('/');
         }
 
-        return redirect(route('voyager.login'));
+        $urlLogin = route('voyager.login');
+        $urlIntended = $request->url();
+        if ($urlIntended == $urlLogin) {
+            $urlIntended = null;
+        }
+
+        return redirect($urlLogin)->with('url.intended', $urlIntended);
     }
 }


### PR DESCRIPTION
This is done by setting the `url.intended` session key in the middleware prior to redirecting to voyager.login.
I'm not sure this is the best way to do this, but it works.
If it's cool, I can also add a config option for this feature.
