### PR TITLE
Allow to order BREAD fields

### DIFF
--- a/publishable/database/migrations/2017_04_21_000000_add_order_to_data_rows_table.php
+++ b/publishable/database/migrations/2017_04_21_000000_add_order_to_data_rows_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOrderToDataRowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('data_rows', function (Blueprint $table) {
+            $table->integer('order')->default('1');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('data_rows', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+}

--- a/resources/views/tools/database/edit-add-bread.blade.php
+++ b/resources/views/tools/database/edit-add-bread.blade.php
@@ -1,5 +1,28 @@
 @extends('voyager::master')
 
+@section('css')
+    <style>
+        .sort-icons {
+            font-size: 21px;
+            color: #ccc;
+            position: relative;
+            cursor: pointer;
+        }
+
+        .sort-icons:hover {
+            color: #37474F;
+        }
+
+        .voyager-sort-asc {
+            top: 10px;
+        }
+        
+        .table a {
+            text-decoration: none;
+        }
+    </style>
+@stop
+
 @section('page_header')
     <div class="page-title">
         <i class="voyager-data"></i> @if(isset($dataType->id)){{ 'Edit BREAD for ' . $dataType->name . ' table' }}@elseif(isset($table)){{ 'Create BREAD for ' . $table . ' table' }}@endif
@@ -153,14 +176,17 @@
                                     </tr>
                                 </thead>
                                 <tbody>
+                                <?php $dataRowOrder = 1 ?>
                                 @foreach($fieldOptions as $data)
-
-                                    @if(isset($dataType->id))
-                                        <?php $dataRow = TCG\Voyager\Models\DataRow::where('data_type_id', '=',
-                                                $dataType->id)->where('field', '=', $data['field'])->first(); ?>
-                                    @endif
                                     <tr>
-                                        <td><h4><strong>{{ $data['field'] }}</strong></h4></td>
+                                        <td>
+                                            <h4><strong>{{ $data['field'] }}</strong></h4>
+                                            <div class="toolbox">
+                                                <a href="" class="sort-button sort-asc"><i class="sort-icons voyager-sort-asc"></i></a>
+                                                <a href="" class="sort-button sort-desc"><i class="sort-icons voyager-sort-desc"></i></a>
+                                                <input type="hidden" value="{{ $dataRowOrder++ }}" name="field_order_{{ $data['field'] }}">
+                                            </div>
+                                        </td>
                                         <td>
                                             <strong>Type:</strong> <span>{{ $data['type'] }}</span><br/>
                                             <strong>Key:</strong> <span>{{ $data['key'] }}</span><br/>
@@ -178,29 +204,29 @@
                                             <input type="checkbox"
                                                    id="field_browse_{{ $data['field'] }}"
                                                    name="field_browse_{{ $data['field'] }}"
-                                                   @if(isset($dataRow->browse) && $dataRow->browse)
+                                                   @if(isset($data->dataRow->browse) && $data->dataRow->browse)
                                                         {{ 'checked="checked"' }}
                                                    @elseif($data['key'] == 'PRI')
                                                    @elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')
-                                                   @elseif(!isset($dataRow->browse))
+                                                   @elseif(!isset($data->dataRow->browse))
                                                         {{ 'checked="checked"' }}
                                                    @endif>
                                             <label for="field_browse_{{ $data['field'] }}">Browse</label><br/>
                                             <input type="checkbox"
                                                    id="field_read_{{ $data['field'] }}"
-                                                   name="field_read_{{ $data['field'] }}" @if(isset($dataRow->read) && $dataRow->read){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($dataRow->read)){{ 'checked="checked"' }}@endif>
+                                                   name="field_read_{{ $data['field'] }}" @if(isset($data->dataRow->read) && $data->dataRow->read){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->read)){{ 'checked="checked"' }}@endif>
                                             <label for="field_read_{{ $data['field'] }}">Read</label><br/>
                                             <input type="checkbox"
                                                    id="field_edit_{{ $data['field'] }}"
-                                                   name="field_edit_{{ $data['field'] }}" @if(isset($dataRow->edit) && $dataRow->edit){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($dataRow->edit)){{ 'checked="checked"' }}@endif>
+                                                   name="field_edit_{{ $data['field'] }}" @if(isset($data->dataRow->edit) && $data->dataRow->edit){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->edit)){{ 'checked="checked"' }}@endif>
                                             <label for="field_edit_{{ $data['field'] }}">Edit</label><br/>
                                             <input type="checkbox"
                                                    id="field_add_{{ $data['field'] }}"
-                                                   name="field_add_{{ $data['field'] }}" @if(isset($dataRow->add) && $dataRow->add){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'created_at')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($dataRow->add)){{ 'checked="checked"' }}@endif>
+                                                   name="field_add_{{ $data['field'] }}" @if(isset($data->dataRow->add) && $data->dataRow->add){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'created_at')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->add)){{ 'checked="checked"' }}@endif>
                                                 <label for="field_add_{{ $data['field'] }}">Add</label><br/>
                                             <input type="checkbox"
                                                    id="field_delete_{{ $data['field'] }}"
-                                                   name="field_delete_{{ $data['field'] }}" @if(isset($dataRow->delete) && $dataRow->delete){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($dataRow->delete)){{ 'checked="checked"' }}@endif>
+                                                   name="field_delete_{{ $data['field'] }}" @if(isset($data->dataRow->delete) && $data->dataRow->delete){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->delete)){{ 'checked="checked"' }}@endif>
                                                     <label for="field_delete_{{ $data['field'] }}">Delete</label><br/>
                                         </td>
                                         <input type="hidden" name="field_{{ $data['field'] }}" value="{{ $data['field'] }}">
@@ -212,7 +238,7 @@
                                             @else
                                                 <select name="field_input_type_{{ $data['field'] }}">
                                                     @foreach (Voyager::formFields() as $formField)
-                                                        <option value="{{ $formField->getCodename() }}" @if(isset($dataRow->type) && $dataRow->type == $formField->getCodename()){{ 'selected' }}@endif>
+                                                        <option value="{{ $formField->getCodename() }}" @if(isset($data->dataRow->type) && $data->dataRow->type == $formField->getCodename()){{ 'selected' }}@endif>
                                                             {{ $formField->getName() }}
                                                         </option>
                                                     @endforeach
@@ -221,13 +247,13 @@
 
                                         </td>
                                         <td><input type="text" class="form-control"
-                                                   value="@if(isset($dataRow->display_name)){{ $dataRow->display_name }}@else{{ ucwords(str_replace('_', ' ', $data['field'])) }}@endif"
+                                                   value="@if(isset($data->dataRow->display_name)){{ $data->dataRow->display_name }}@else{{ ucwords(str_replace('_', ' ', $data['field'])) }}@endif"
                                                    name="field_display_name_{{ $data['field'] }}"></td>
                                         <td>
                                             <div class="alert alert-danger validation-error">
                                                 Invalid JSON
                                             </div>
-                                            <textarea id="json-input-{{ $data['field'] }}" class="resizable-editor" data-editor="json" name="field_details_{{ $data['field'] }}">@if(isset($dataRow->details)){{ $dataRow->details }}@endif</textarea>
+                                            <textarea id="json-input-{{ $data['field'] }}" class="resizable-editor" data-editor="json" name="field_details_{{ $data['field'] }}">@if(isset($data->dataRow->details)){{ $data->dataRow->details }}@endif</textarea>
                                         </td>
                                     </tr>
 
@@ -350,6 +376,23 @@
             $('[data-toggle="tooltip"]').tooltip();
 
             $('.toggleswitch').bootstrapToggle();
+            
+            $('a.sort-button').click(function (ev) {
+                ev.preventDefault();
+                
+                var direction = $(ev.currentTarget).hasClass('sort-asc') ? 'up' : 'down';
+                var row = $(ev.currentTarget).closest('tr');
+                var target_row = direction == 'up' ? row.prev('tr') : row.next('tr');
+                
+                if (target_row.length == 1) {
+                    direction == 'up' ? target_row.before(row) : target_row.after(row);
+                    var order_input = row.find('input[name^=field_order_]');
+                    var order_input_target = target_row.find('input[name^=field_order_]');
+                    var swap = order_input.val();
+                    order_input.val(order_input_target.val());
+                    order_input_target.val(swap);
+                }
+            });
         });
     </script>
 @stop

--- a/resources/views/tools/database/edit-add-bread.blade.php
+++ b/resources/views/tools/database/edit-add-bread.blade.php
@@ -204,29 +204,29 @@
                                             <input type="checkbox"
                                                    id="field_browse_{{ $data['field'] }}"
                                                    name="field_browse_{{ $data['field'] }}"
-                                                   @if(isset($data->dataRow->browse) && $data->dataRow->browse)
+                                                   @if(isset($data['dataRow']->browse) && $data['dataRow']->browse)
                                                         {{ 'checked="checked"' }}
                                                    @elseif($data['key'] == 'PRI')
                                                    @elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')
-                                                   @elseif(!isset($data->dataRow->browse))
+                                                   @elseif(!isset($data['dataRow']->browse))
                                                         {{ 'checked="checked"' }}
                                                    @endif>
                                             <label for="field_browse_{{ $data['field'] }}">Browse</label><br/>
                                             <input type="checkbox"
                                                    id="field_read_{{ $data['field'] }}"
-                                                   name="field_read_{{ $data['field'] }}" @if(isset($data->dataRow->read) && $data->dataRow->read){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->read)){{ 'checked="checked"' }}@endif>
+                                                   name="field_read_{{ $data['field'] }}" @if(isset($data['dataRow']->read) && $data['dataRow']->read){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data['dataRow']->read)){{ 'checked="checked"' }}@endif>
                                             <label for="field_read_{{ $data['field'] }}">Read</label><br/>
                                             <input type="checkbox"
                                                    id="field_edit_{{ $data['field'] }}"
-                                                   name="field_edit_{{ $data['field'] }}" @if(isset($data->dataRow->edit) && $data->dataRow->edit){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->edit)){{ 'checked="checked"' }}@endif>
+                                                   name="field_edit_{{ $data['field'] }}" @if(isset($data['dataRow']->edit) && $data['dataRow']->edit){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data['dataRow']->edit)){{ 'checked="checked"' }}@endif>
                                             <label for="field_edit_{{ $data['field'] }}">Edit</label><br/>
                                             <input type="checkbox"
                                                    id="field_add_{{ $data['field'] }}"
-                                                   name="field_add_{{ $data['field'] }}" @if(isset($data->dataRow->add) && $data->dataRow->add){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'created_at')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->add)){{ 'checked="checked"' }}@endif>
+                                                   name="field_add_{{ $data['field'] }}" @if(isset($data['dataRow']->add) && $data['dataRow']->add){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'created_at')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data['dataRow']->add)){{ 'checked="checked"' }}@endif>
                                                 <label for="field_add_{{ $data['field'] }}">Add</label><br/>
                                             <input type="checkbox"
                                                    id="field_delete_{{ $data['field'] }}"
-                                                   name="field_delete_{{ $data['field'] }}" @if(isset($data->dataRow->delete) && $data->dataRow->delete){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data->dataRow->delete)){{ 'checked="checked"' }}@endif>
+                                                   name="field_delete_{{ $data['field'] }}" @if(isset($data['dataRow']->delete) && $data['dataRow']->delete){{ 'checked="checked"' }}@elseif($data['key'] == 'PRI')@elseif($data['type'] == 'timestamp' && $data['field'] == 'updated_at')@elseif(!isset($data['dataRow']->delete)){{ 'checked="checked"' }}@endif>
                                                     <label for="field_delete_{{ $data['field'] }}">Delete</label><br/>
                                         </td>
                                         <input type="hidden" name="field_{{ $data['field'] }}" value="{{ $data['field'] }}">
@@ -238,7 +238,7 @@
                                             @else
                                                 <select name="field_input_type_{{ $data['field'] }}">
                                                     @foreach (Voyager::formFields() as $formField)
-                                                        <option value="{{ $formField->getCodename() }}" @if(isset($data->dataRow->type) && $data->dataRow->type == $formField->getCodename()){{ 'selected' }}@endif>
+                                                        <option value="{{ $formField->getCodename() }}" @if(isset($data['dataRow']->type) && $data['dataRow']->type == $formField->getCodename()){{ 'selected' }}@endif>
                                                             {{ $formField->getName() }}
                                                         </option>
                                                     @endforeach
@@ -247,13 +247,13 @@
 
                                         </td>
                                         <td><input type="text" class="form-control"
-                                                   value="@if(isset($data->dataRow->display_name)){{ $data->dataRow->display_name }}@else{{ ucwords(str_replace('_', ' ', $data['field'])) }}@endif"
+                                                   value="@if(isset($data['dataRow']->display_name)){{ $data['dataRow']->display_name }}@else{{ ucwords(str_replace('_', ' ', $data['field'])) }}@endif"
                                                    name="field_display_name_{{ $data['field'] }}"></td>
                                         <td>
                                             <div class="alert alert-danger validation-error">
                                                 Invalid JSON
                                             </div>
-                                            <textarea id="json-input-{{ $data['field'] }}" class="resizable-editor" data-editor="json" name="field_details_{{ $data['field'] }}">@if(isset($data->dataRow->details)){{ $data->dataRow->details }}@endif</textarea>
+                                            <textarea id="json-input-{{ $data['field'] }}" class="resizable-editor" data-editor="json" name="field_details_{{ $data['field'] }}">@if(isset($data['dataRow']->details)){{ $data['dataRow']->details }}@endif</textarea>
                                         </td>
                                     </tr>
 

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -150,7 +150,10 @@ class DataType extends Model
             return $item;
         });
         
-        $fieldOptions = $fieldOptions->sortBy('dataRow.order');
+        //Sort by DataRow order field, put new fields at the end
+        $fieldOptions = $fieldOptions->sortBy(function ($elt) {
+            return isset($elt['dataRow']) ? $elt['dataRow']->order : PHP_INT_MAX;
+        });
 
         if ($extraFields = $this->extraFields()) {
             foreach ($extraFields as $field) {

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -31,7 +31,7 @@ class DataType extends Model
 
     public function rows()
     {
-        return $this->hasMany(Voyager::modelClass('DataRow'));
+        return $this->hasMany(Voyager::modelClass('DataRow'))->orderBy('order');
     }
 
     public function browseRows()
@@ -89,6 +89,7 @@ class DataType extends Model
                     $dataRow->type = $requestData['field_input_type_'.$field];
                     $dataRow->details = $requestData['field_details_'.$field];
                     $dataRow->display_name = $requestData['field_display_name_'.$field];
+                    $dataRow->order = $requestData['field_order_'.$field];
 
                     if (!$dataRow->save()) {
                         throw new \Exception('Failed to save field '.$field.", we're rolling back!");
@@ -142,6 +143,14 @@ class DataType extends Model
         $table = $this->name;
 
         $fieldOptions = SchemaManager::describeTable($table);
+        
+        //Add dataRows information to the collection
+        $fieldOptions->transform(function ($item, $key) {
+            $item['dataRow'] = $this->rows->where('field', $item['field'])->first();
+            return $item;
+        });
+        
+        $fieldOptions = $fieldOptions->sortBy('dataRow.order');
 
         if ($extraFields = $this->extraFields()) {
             foreach ($extraFields as $field) {


### PR DESCRIPTION
This is my attempt at allowing ordering of BREAD fields.
It relies on an `order` column in the `data_rows` table (requires to run migrations).

Most is done in the `edit-add-bread` view (could be improved with drag and drop) with a bit of sorting done in `$dataType->fieldOptions()`. Also added the dataRow object as part of the `fieldOptions` array as we're fetching it there to avoid querying it in the view.

Issues:
- New columns are added at the end instead of their actual place in DB (if added using 'after' in phpmyadmin for example)
