### PR TITLE
allow number formfield to accept decimals

### DIFF
--- a/resources/views/formfields/number.blade.php
+++ b/resources/views/formfields/number.blade.php
@@ -1,3 +1,3 @@
-<input type="number" class="form-control" name="{{ $row->field }}"
+<input type="number" step="any" class="form-control" name="{{ $row->field }}"
         placeholder="{{ isset($options->placeholder)? old($row->field, $options->placeholder): $row->display_name }}"
        value="@if(isset($dataTypeContent->{$row->field})){{ old($row->field, $dataTypeContent->{$row->field}) }}@else{{old($row->field)}}@endif">


### PR DESCRIPTION
- Reason(s):
  - the validator on the number formfield does not allow decimals

- Change(s):
  - added step="any" to the number formfield

- Reference(s):
  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number