### PR TITLE
[fix] Boot User VoyagerServiceProvider

### DIFF
--- a/src/Commands/AdminCommand.php
+++ b/src/Commands/AdminCommand.php
@@ -106,7 +106,7 @@ class AdminCommand extends Command
     {
         $email = $this->argument('email');
 
-        $model = config('voyager.user.namespace', 'App\\User');
+        $model = Voyager::model('User');
 
         // If we need to create a new user go ahead and create it
         if ($create) {

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -56,6 +56,8 @@ class Voyager
     {
         $this->filesystem = app(Filesystem::class);
 
+        $this->models['User'] = config('voyager.user.namespace', User::class);
+
         $this->findVersion();
     }
 
@@ -287,7 +289,7 @@ class Voyager
         }
 
         if (!isset($this->users[$id])) {
-            $this->users[$id] = User::find($id);
+            $this->users[$id] = $this->model('User')::find($id);
         }
 
         return $this->users[$id];

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -289,7 +289,7 @@ class Voyager
         }
 
         if (!isset($this->users[$id])) {
-            $this->users[$id] = $this->model('User')::find($id);
+            $this->users[$id] = $this->model('User')->find($id);
         }
 
         return $this->users[$id];

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -63,7 +63,7 @@ class VoyagerServiceProvider extends ServiceProvider
             $app_user = config('voyager.user.namespace', User::class);
             $app_user::created(function ($user) {
                 if (is_null($user->role_id)) {
-                    $user->findOrFail($user->id)
+                    VoyagerFacade::model('User')->findOrFail($user->id)
                         ->setRole(config('voyager.user.default_role'))
                         ->save();
                 }

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -60,10 +60,10 @@ class VoyagerServiceProvider extends ServiceProvider
     public function boot(Router $router, Dispatcher $event)
     {
         if (config('voyager.user.add_default_role_on_register')) {
-            $app_user = config('voyager.user.namespace');
+            $app_user = config('voyager.user.namespace', User::class);
             $app_user::created(function ($user) {
                 if (is_null($user->role_id)) {
-                    VoyagerFacade::model('User')->findOrFail($user->id)
+                    $user->findOrFail($user->id)
                         ->setRole(config('voyager.user.default_role'))
                         ->save();
                 }


### PR DESCRIPTION
This fixes user boot at VoyagerServiceProvider, when running `php artisan voyager:admin name@domain.tld`. It happens when using another table name for `users`.

It wasn't using the config from `voyager.user.namespace`.