### PR TITLE
Fixed Migration failed if 'avatar' field already exists

### DIFF
--- a/publishable/database/migrations/2016_01_01_000000_add_voyager_user_fields.php
+++ b/publishable/database/migrations/2016_01_01_000000_add_voyager_user_fields.php
@@ -10,7 +10,9 @@ class AddVoyagerUserFields extends Migration
     public function up()
     {
         Schema::table('users', function ($table) {
-            $table->string('avatar')->nullable()->after('email');
+            if (!Schema::hasColumn('users', 'avatar')) {
+                $table->string('avatar')->nullable()->after('email');
+            }
             $table->integer('role_id')->nullable()->after('id');
         });
     }


### PR DESCRIPTION
Migrating the database tables into your application


  [Illuminate\Database\QueryException]
  SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'avatar' (SQL: alter table `users` add `avatar` varchar(191) n
  ull after `email`, add `role_id` int null after `id`)



  [Doctrine\DBAL\Driver\PDOException]
  SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'avatar'



  [PDOException]
  SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'avatar'