### PR TITLE
Fixed breadcrumb issue if site root != /

### DIFF
--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -17,7 +17,7 @@
                         <a href="{{ route('voyager.dashboard')}}"><i class="voyager-boat"></i> Dashboard</a>
                     </li>
                 @endif
-                <?php $breadcrumb_url = ''; ?>
+                <?php $breadcrumb_url = url(''); ?>
                 @for($i = 1; $i <= count(Request::segments()); $i++)
                     <?php $breadcrumb_url .= '/' . Request::segment($i); ?>
                     @if(Request::segment($i) != ltrim(route('voyager.dashboard', [], false), '/') && !is_numeric(Request::segment($i)))


### PR DESCRIPTION
Breadcrumb generation did not use the url() helper thus assuming base url is always '/'