### PR TITLE
Enforce sortBy PK id

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -44,7 +44,10 @@ class VoyagerBreadController extends Controller
             if ($model->timestamps) {
                 $dataTypeContent = call_user_func([$model->with($relationships)->latest(), $getter]);
             } else {
-                $dataTypeContent = call_user_func([$model->with($relationships)->orderBy($model->getKeyName(), 'DESC'), $getter]);
+                $dataTypeContent = call_user_func([
+                    $model->with($relationships)->orderBy($model->getKeyName(), 'DESC'),
+                    $getter
+                ]);
             }
 
             //Replace relationships' keys for labels and create READ links if a slug is provided.

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -44,7 +44,7 @@ class VoyagerBreadController extends Controller
             if ($model->timestamps) {
                 $dataTypeContent = call_user_func([$model->with($relationships)->latest(), $getter]);
             } else {
-                $dataTypeContent = call_user_func([$model->with($relationships)->orderBy('id', 'DESC'), $getter]);
+                $dataTypeContent = call_user_func([$model->with($relationships)->orderBy($model->getKeyName(), 'DESC'), $getter]);
             }
 
             //Replace relationships' keys for labels and create READ links if a slug is provided.

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -46,7 +46,7 @@ class VoyagerBreadController extends Controller
             } else {
                 $dataTypeContent = call_user_func([
                     $model->with($relationships)->orderBy($model->getKeyName(), 'DESC'),
-                    $getter
+                    $getter,
                 ]);
             }
 


### PR DESCRIPTION
When using a different name for `id` in a table, we have to enforce that the sortBy is using the PK defined in the model `protected $primaryKey = 'custom_id'`.


