### PR TITLE
Added ability to configure datepicker for date fields

### DIFF
--- a/resources/views/bread/edit-add.blade.php
+++ b/resources/views/bread/edit-add.blade.php
@@ -125,6 +125,15 @@
 
         $('document').ready(function () {
             $('.toggleswitch').bootstrapToggle();
+            
+            //Init datepicker for date fields if data-datepicker attribute defined
+            //or if browser does not handle date inputs
+            $('.form-group input[type=date]').each(function (idx, elt) {
+                if (elt.type != 'date' || elt.hasAttribute('data-datepicker')) {
+                    elt.type = 'text';
+                    $(elt).datetimepicker($(elt).data('datepicker'));
+                }
+            });
 
             @if ($isModelTranslatable)
                 $('.side-body').multilingual({"editing": true});

--- a/resources/views/formfields/date.blade.php
+++ b/resources/views/formfields/date.blade.php
@@ -1,3 +1,4 @@
 <input type="date" class="form-control" name="{{ $row->field }}"
        placeholder="{{ $row->display_name }}"
-       value="@if(isset($dataTypeContent->{$row->field})){{ gmdate('Y-m-d', strtotime(old($row->field, $dataTypeContent->{$row->field}))) }}@else{{old($row->field)}}@endif">
+       value="@if(isset($dataTypeContent->{$row->field})){{ gmdate('Y-m-d', strtotime(old($row->field, $dataTypeContent->{$row->field}))) }}@else{{old($row->field)}}@endif"
+       @if(isset($options->datepicker))data-datepicker="{!! htmlentities(json_encode($options->datepicker), ENT_QUOTES, 'UTF-8') !!}"@endif>


### PR DESCRIPTION
**Current behaviour:**
Date picker is up to the browser (`<input type="date"/>`).

**Suggested behaviour:**
- Default: Date picker is up to the browser if available, otherwise fallback to BootstrapDatePicker (as used for timestamps)
- Custom: If `datepicker` is defined on BREAD field's option: Use BootstrapDatePicker with provided parameters

Example BREAD option:
```
{
    "datepicker": {
        "format": "YYYY-MM-DD",
        "defaultDate": "1990-01-01"
    }
}
```