### PR TITLE
Add GeometryType for Postgresql

### DIFF
--- a/src/Database/Types/Postgresql/GeometryType.php
+++ b/src/Database/Types/Postgresql/GeometryType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TCG\Voyager\Database\Types\Postgresql;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use TCG\Voyager\Database\Types\Type;
+
+class GeometryType extends Type
+{
+    const NAME = 'geometry';
+
+    public function getSQLDeclaration(array $field, AbstractPlatform $platform)
+    {
+        return 'geometry';
+    }
+}


### PR DESCRIPTION
Fixes #1205

@abolinhas please test this. Make sure you can create new columns with `GEOMETRY` type without errors.