### PR TITLE
adding admin_bg_color option

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -13,6 +13,7 @@
     <style>
         body {
             background-image:url('{{ Voyager::image( Voyager::setting("admin_bg_image"), config('voyager.assets_path') . "/images/bg.jpg" ) }}');
+            background-color: {{ Voyager::setting("admin_bg_color", "#FFFFFF" ) }};
         }
         .login-sidebar:after {
             background: linear-gradient(-135deg, {{config('voyager.login.gradient_a','#ffffff')}}, {{config('voyager.login.gradient_b','#ffffff')}});


### PR DESCRIPTION
For custom background colors on login page. I have this on my own setup. I have a partially transparent background image and implemented this so I have the option to change the default background color. Follows the same format as other background options. Defaults to #FFFFFF.