### PR TITLE
BREAD field-width feature

### DIFF
--- a/resources/views/bread/edit-add.blade.php
+++ b/resources/views/bread/edit-add.blade.php
@@ -61,7 +61,7 @@
                             @endif
 
                             @foreach($dataTypeRows as $row)
-                                <div class="form-group @if($row->type == 'hidden') hidden @endif">
+                                <div class="form-group @if($row->type == 'hidden') hidden @endif col-md-{{$row->col_width}}">
                                     <label for="name">{{ $row->display_name }}</label>
                                     @include('voyager::multilingual.input-hidden-bread-edit-add')
                                     {!! app('voyager')->formField($row, $dataType, $dataTypeContent) !!}
@@ -125,7 +125,7 @@
 
         $('document').ready(function () {
             $('.toggleswitch').bootstrapToggle();
-            
+
             //Init datepicker for date fields if data-datepicker attribute defined
             //or if browser does not handle date inputs
             $('.form-group input[type=date]').each(function (idx, elt) {

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -142,6 +142,11 @@ class VoyagerBreadController extends Controller
             ? app($dataType->model_name)->with($relationships)->findOrFail($id)
             : DB::table($dataType->name)->where('id', $id)->first(); // If Model doest exist, get data from table name
 
+        foreach ($dataType->editRows as $key => $row) {
+            $details = json_decode($row->details);
+            $dataType->editRows[$key]['col_width'] = $this->parseWidth(@$details->width);
+        }
+
         // Check if BREAD is Translatable
         $isModelTranslatable = is_bread_translatable($dataTypeContent);
 
@@ -210,6 +215,11 @@ class VoyagerBreadController extends Controller
         $dataTypeContent = (strlen($dataType->model_name) != 0)
                             ? new $dataType->model_name()
                             : false;
+
+        foreach ($dataType->addRows as $key => $row) {
+            $details = json_decode($row->details);
+            $dataType->addRows[$key]['col_width'] = $this->parseWidth(@$details->width);
+        }
 
         // Check if BREAD is Translatable
         $isModelTranslatable = is_bread_translatable($dataTypeContent);
@@ -312,5 +322,25 @@ class VoyagerBreadController extends Controller
             ];
 
         return redirect()->route("voyager.{$dataType->slug}.index")->with($data);
+    }
+
+    private function parseWidth($width)
+    {
+        switch ($width) {
+            case 'full':
+                return 12;
+            case 'half':
+                return 6;
+            case 'onefourth':
+                return 3;
+            case 'threefirth':
+                return 9;
+            case 'onethird':
+                return 4;
+            case 'twothird':
+                return 8;
+            default:
+                return 12;
+        }
     }
 }


### PR DESCRIPTION
Enables the user to set the width of a form-field in the add/edit page.
To set the width write in the optional details field:
`{
    "width": "half"
}`

Possible values are 
- full
- half
- onefourth
- threefirth
- onethird
- twothird

Default is full