### PR TITLE
Cache settings in memory to avoid querying multiple times

### DIFF
--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -52,7 +52,7 @@ class Voyager
         'User'       => User::class,
     ];
 
-    private $setting_cache = [];
+    public $setting_cache = null;
 
     public function __construct()
     {
@@ -138,13 +138,11 @@ class Voyager
 
     public function setting($key, $default = null)
     {
-        if (! isset($this->setting_cache[$key]))
-        {
-            $setting = Setting::where('key', '=', $key)->first();
-            $this->setting_cache[$key] = isset($setting->id) ? $setting->value : $default;
+        if ($this->setting_cache === null) {
+            $this->setting_cache = Setting::pluck('value', 'key');
         }
 
-        return $this->setting_cache[$key];
+        return $this->setting_cache->get($key) ?: $default;
     }
 
     public function image($file, $default = '')

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -52,6 +52,8 @@ class Voyager
         'User'       => User::class,
     ];
 
+    private $setting_cache = [];
+
     public function __construct()
     {
         $this->filesystem = app(Filesystem::class);
@@ -136,13 +138,13 @@ class Voyager
 
     public function setting($key, $default = null)
     {
-        $setting = Setting::where('key', '=', $key)->first();
-
-        if (isset($setting->id)) {
-            return $setting->value;
+        if (! isset($this->setting_cache[$key]))
+        {
+            $setting = Setting::where('key', '=', $key)->first();
+            $this->setting_cache[$key] = isset($setting->id) ? $setting->value : $default;
         }
 
-        return $default;
+        return $this->setting_cache[$key];
     }
 
     public function image($file, $default = '')


### PR DESCRIPTION
**Current behavior:**
The DB is queried each time a setting is retrieved with `Voyager::setting()`

**Proposed behavior**
Locally cache settings in a private array on the Voyager object so that their are each queried only once.