### PR TITLE
Set laravel/framework required at composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,21 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.3.0|~5.4.0",
-        "intervention/image": "^2.3",
-        "doctrine/dbal": "^2.5",
-        "larapack/doctrine-support": "~0.1.0",
         "arrilot/laravel-widgets": "^3.7",
+        "doctrine/dbal": "^2.5",
+        "intervention/image": "^2.3",
+        "larapack/doctrine-support": "~0.1.0",
+        "laravel/framework": "~5.3.29|5.4.*",
         "league/flysystem": "~1.0.35"
     },
     "require-dev": {
-        "phpunit/phpcov": "~3.0",
-        "phpunit/phpunit": "~5.7.14",
-        "laravel/framework": "~5.3.29|5.4.*",
-        "orchestra/testbench": "3.3.*|3.4.x-dev",
-        "orchestra/database": "3.3.*|3.4.x-dev",
+        "codeclimate/php-test-reporter": "dev-master",
         "laravel/browser-kit-testing": "~1.0.0",
+        "orchestra/database": "3.3.*|3.4.x-dev",
+        "orchestra/testbench": "3.3.*|3.4.x-dev",
         "orchestra/testbench-browser-kit": "~3.3.0|~3.4.0",
-        "codeclimate/php-test-reporter": "dev-master"
+        "phpunit/phpcov": "~3.0",
+        "phpunit/phpunit": "~5.7.14"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The `laravel/framework` is now required at composer.json. Some cleanup done.