### PR TITLE
Added field name in "label for" and "input id"

### DIFF
--- a/resources/views/formfields/radio_btn.blade.php
+++ b/resources/views/formfields/radio_btn.blade.php
@@ -6,10 +6,10 @@
     @if(isset($options->options))
         @foreach($options->options as $key => $option)
             <li>
-                <input type="radio" id="option-{{ $key }}"
+                <input type="radio" id="option-{{ str_slug($row->field, '-') }}-{{ str_slug($key, '-') }}"
                        name="{{ $row->field }}"
                        value="{{ $key }}" @if($default == $key && $selected_value === NULL){{ 'checked' }}@endif @if($selected_value == $key){{ 'checked' }}@endif>
-                <label for="option-{{ $key }}">{{ $option }}</label>
+                <label for="option-{{ str_slug($row->field, '-') }}-{{ str_slug($key, '-') }}">{{ $option }}</label>
                 <div class="check"></div>
             </li>
         @endforeach


### PR DESCRIPTION
[Forms] When you enter more than one radio field of the same value, a conflict occurs because they have the same id.

Example:

Field: Display
Options: Yes (id: option-Yes) | No (id: option-No)

Field: Featured
Options: Yes (id: option-Yes) | No (id: option-No)