### PR TITLE
Fix for saving field like a null

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -61,10 +61,6 @@ abstract class Controller extends BaseController
             }
 
             if (is_null($content)) {
-                // Only set the content back to the previous value when there is really now input for this field
-                if (is_null($request->input($row->field)) && isset($data->{$row->field})) {
-                    $content = $data->{$row->field};
-                }
                 if ($row->field == 'password') {
                     $content = $data->{$row->field};
                 }


### PR DESCRIPTION
I fixed possibility to saving field like a null. I thougth rules validation like "`sometimes|nullable`" will be enough but wasn't. When we tried to save empty field, it was not active into $date variable so we need remove this part of code for let us saving field like a empty(null) value. I tested it and i don't see any issues, but if someone could test it again, i will be appreciated.

@akazorg I tested issue with rules and it was not worked so i did a PR for fix it.
#1331