### PR TITLE
Fix FatalThrowableError

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -120,7 +120,7 @@
                         </table>
                         @if (isset($dataType->server_side) && $dataType->server_side)
                             <div class="pull-left">
-                                <div role="status" class="show-res" aria-live="polite">{{ __(
+                                <div role="status" class="show-res" aria-live="polite">{{ trans_choice(
                                     'voyager.generic.showing_entries', $dataTypeContent->total(), [
                                         'from' => $dataTypeContent->firstItem(),
                                         'to' => $dataTypeContent->lastItem(),


### PR DESCRIPTION
Fix error with field translation:
Type error: Argument 2 passed to
Illuminate\Translation\Translator::getFromJson() must be of the type
array, integer given, called in
\vendor\laravel\framework\src\Illuminate\Foundation\helpers.php on line
819 (View: vendor\tcg\voyager\resources\views\bread\browse.blade.php)
line 123