### PR TITLE
Remove dummy text from menu builder

### DIFF
--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -16,7 +16,7 @@
             <div class="col-md-12">
                 <div class="panel panel-bordered">
                     <div class="panel-heading">
-                        <p class="panel-title" style="color:#777">zz{{ __('voyager.menu_builder.drag_drop_info') }}</p>
+                        <p class="panel-title" style="color:#777">{{ __('voyager.menu_builder.drag_drop_info') }}</p>
                     </div>
 
                     <div class="panel-body" style="padding:30px;">


### PR DESCRIPTION
Clear useless string I left at menu `builder.blade.php`.