### PR TITLE
Two add_timestamps buttons on Database Helpers

### DIFF
--- a/resources/views/tools/database/vue-components/database-table-helper-buttons.blade.php
+++ b/resources/views/tools/database/vue-components/database-table-helper-buttons.blade.php
@@ -2,7 +2,7 @@
     <div>
         <div class="btn btn-success" @click="addNewColumn">+ {{ __('voyager.database.add_new_column') }}</div>
         <div class="btn btn-success" @click="addTimestamps">+ {{ __('voyager.database.add_timestamps') }}</div>
-        <div class="btn btn-success" @click="addSoftDeletes">+ {{ __('voyager.database.add_timestamps') }}</div>
+        <div class="btn btn-success" @click="addSoftDeletes">+ {{ __('voyager.database.add_softdeletes') }}</div>
     </div>
 @endsection
 


### PR DESCRIPTION
Hello, I see that in the helpers buttons of the database appears the add_timestamps button repeated instead of the softdelete button.

Regards