### PR TITLE
Spatial column type support using a Google map 

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -228,12 +228,12 @@ return [
     ],
 
     'googlemaps' => [
-        'key' => env('GOOGLE_MAPS_KEY'),
+        'key'    => env('GOOGLE_MAPS_KEY'),
         'center' => [
             'lat' => env('GOOGLE_MAPS_DEFAULT_CENTER_LAT'),
             'lng' => env('GOOGLE_MAPS_DEFAULT_CENTER_LNG'),
         ],
         'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM')
-    ]
+    ],
 
 ];

--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -230,10 +230,10 @@ return [
     'googlemaps' => [
         'key'    => env('GOOGLE_MAPS_KEY'),
         'center' => [
-            'lat' => env('GOOGLE_MAPS_DEFAULT_CENTER_LAT'),
-            'lng' => env('GOOGLE_MAPS_DEFAULT_CENTER_LNG'),
+            'lat' => '',
+            'lng' => '',
         ],
-        'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM'),
+        'zoom' => '',
     ],
 
 ];

--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -227,4 +227,13 @@ return [
         //'js/custom.js',
     ],
 
+    'googlemaps' => [
+        'key' => env('GOOGLE_MAPS_KEY'),
+        'center' => [
+            'lat' => env('GOOGLE_MAPS_DEFAULT_CENTER_LAT'),
+            'lng' => env('GOOGLE_MAPS_DEFAULT_CENTER_LNG'),
+        ],
+        'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM')
+    ]
+
 ];

--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -233,7 +233,7 @@ return [
             'lat' => env('GOOGLE_MAPS_DEFAULT_CENTER_LAT'),
             'lng' => env('GOOGLE_MAPS_DEFAULT_CENTER_LNG'),
         ],
-        'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM')
+        'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM'),
     ],
 
 ];

--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -228,12 +228,12 @@ return [
     ],
 
     'googlemaps' => [
-        'key'    => env('GOOGLE_MAPS_KEY'),
-        'center' => [
-            'lat' => '',
-            'lng' => '',
-        ],
-        'zoom' => '',
-    ],
+         'key'    => env('GOOGLE_MAPS_KEY', ''),
+         'center' => [
+             'lat' => env('GOOGLE_MAPS_DEFAULT_CENTER_LAT', '32.715738'),
+             'lng' => env('GOOGLE_MAPS_DEFAULT_CENTER_LNG', '-117.161084'),
+         ],
+         'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM', 11),
+     ],
 
 ];

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -91,6 +91,8 @@
                                             @elseif($row->type == 'rich_text_box')
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
                                                 <div class="readmore">{{ strlen( strip_tags($data->{$row->field}, '<b><i><u>') ) > 200 ? substr(strip_tags($data->{$row->field}, '<b><i><u>'), 0, 200) . ' ...' : strip_tags($data->{$row->field}, '<b><i><u>') }}</div>
+                                            @elseif($row->type == 'coordinates')
+                                                @include('voyager::partials.coordinates-static-image')
                                             @else
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
                                                 <span>{{ $data->{$row->field} }}</span>

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -76,6 +76,8 @@
                                 @else
                                 {{ $dataTypeContent->{$row->field} }}
                                 @endif
+                            @elseif($row->type == 'coordinates')
+                                @include('voyager::partials.coordinates')
                             @elseif($row->type == 'rich_text_box')
                                 @include('voyager::multilingual.input-hidden-bread-read')
                                 <p>{{ strip_tags($dataTypeContent->{$row->field}, '<b><i><u>') }}</p>

--- a/resources/views/formfields/coordinates.blade.php
+++ b/resources/views/formfields/coordinates.blade.php
@@ -1,0 +1,30 @@
+<style>
+    #map {
+        height: 400px;
+        width: 100%;
+    }
+</style>
+<input type="hidden" name="{{ $row->field }}[lat]" value="{{ config('voyager.googlemaps.center.lat') }}" id="lat"/>
+<input type="hidden" name="{{ $row->field }}[lng]" value="{{ config('voyager.googlemaps.center.lng') }}" id="lng"/>
+
+<script type="application/javascript">
+    function initMap() {
+        var center = {lat: {{ config('voyager.googlemaps.center.lat') }}, lng: {{ config('voyager.googlemaps.center.lng') }}};
+        var map = new google.maps.Map(document.getElementById('map'), {
+            zoom: {{ config('voyager.googlemaps.zoom') }},
+            center: center
+        });
+        var marker = new google.maps.Marker({
+            position: center,
+            map: map,
+            draggable: true
+        });
+
+        google.maps.event.addListener(marker,'dragend',function(event) {
+            document.getElementById('lat').value = this.position.lat();
+            document.getElementById('lng').value = this.position.lng();
+        });
+    }
+</script>
+<div id="map"/>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ config('voyager.googlemaps.key') }}&callback=initMap"></script>

--- a/resources/views/formfields/coordinates.blade.php
+++ b/resources/views/formfields/coordinates.blade.php
@@ -4,12 +4,21 @@
         width: 100%;
     }
 </style>
-<input type="hidden" name="{{ $row->field }}[lat]" value="{{ config('voyager.googlemaps.center.lat') }}" id="lat"/>
-<input type="hidden" name="{{ $row->field }}[lng]" value="{{ config('voyager.googlemaps.center.lng') }}" id="lng"/>
+@forelse($dataTypeContent->getCoordinates() as $point)
+    <input type="hidden" name="{{ $row->field }}[lat]" value="{{ $point['lat'] }}" id="lat"/>
+    <input type="hidden" name="{{ $row->field }}[lng]" value="{{ $point['lng'] }}" id="lng"/>
+@empty
+    <input type="hidden" name="{{ $row->field }}[lat]" value="{{ config('voyager.googlemaps.center.lat') }}" id="lat"/>
+    <input type="hidden" name="{{ $row->field }}[lng]" value="{{ config('voyager.googlemaps.center.lng') }}" id="lng"/>
+@endforelse
 
 <script type="application/javascript">
     function initMap() {
-        var center = {lat: {{ config('voyager.googlemaps.center.lat') }}, lng: {{ config('voyager.googlemaps.center.lng') }}};
+        @forelse($dataTypeContent->getCoordinates() as $point)
+            var center = {lat: {{ $point['lat'] }}, lng: {{ $point['lng'] }}};
+        @empty
+            var center = {lat: {{ config('voyager.googlemaps.center.lat') }}, lng: {{ config('voyager.googlemaps.center.lng') }}};
+        @endforelse
         var map = new google.maps.Map(document.getElementById('map'), {
             zoom: {{ config('voyager.googlemaps.zoom') }},
             center: center

--- a/resources/views/partials/coordinates-static-image.blade.php
+++ b/resources/views/partials/coordinates-static-image.blade.php
@@ -1,0 +1,1 @@
+<img src="https://maps.googleapis.com/maps/api/staticmap?zoom={{ config('voyager.googlemaps.zoom') }}&size=400x100&maptype=roadmap&@foreach($data->getCoordinates() as $point)markers=color:red%7C{{ $point['lat'] }},{{ $point['lng'] }}&center={{ $point['lat'] }},{{ $point['lng'] }}@endforeach&key={{ config('voyager.googlemaps.key') }}"/>

--- a/resources/views/partials/coordinates.blade.php
+++ b/resources/views/partials/coordinates.blade.php
@@ -4,8 +4,6 @@
         width: 100%;
     }
 </style>
-<input type="hidden" name="{{ $row->field }}[lat]" value="{{ config('voyager.googlemaps.center.lat') }}" id="lat"/>
-<input type="hidden" name="{{ $row->field }}[lng]" value="{{ config('voyager.googlemaps.center.lng') }}" id="lng"/>
 
 <script type="application/javascript">
     function initMap() {
@@ -15,25 +13,13 @@
             center: center
         });
         var markers = [];
-        @forelse($dataTypeContent->getCoordinates() as $point)
+        @foreach($dataTypeContent->getCoordinates() as $point)
             var marker = new google.maps.Marker({
                     position: {lat: {{ $point['lat'] }}, lng: {{ $point['lng'] }}},
-                    map: map,
-                    draggable: true
+                    map: map
                 });
             markers.push(marker);
-        @empty
-            var marker = new google.maps.Marker({
-                    position: center,
-                    map: map,
-                    draggable: true
-                });
-        @endforelse
-
-        google.maps.event.addListener(marker,'dragend',function(event) {
-            document.getElementById('lat').value = this.position.lat();
-            document.getElementById('lng').value = this.position.lng();
-        });
+        @endforeach
     }
 </script>
 <div id="map"/>

--- a/src/FormFields/CoordinatesHandler.php
+++ b/src/FormFields/CoordinatesHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TCG\Voyager\FormFields;
+
+class CoordinatesHandler  extends AbstractHandler
+{
+    protected $codename = 'coordinates';
+
+    public function createContent($row, $dataType, $dataTypeContent, $options)
+    {
+        return view('voyager::formfields.coordinates', [
+            'row'             => $row,
+            'options'         => $options,
+            'dataType'        => $dataType,
+            'dataTypeContent' => $dataTypeContent,
+        ]);
+    }
+}

--- a/src/FormFields/CoordinatesHandler.php
+++ b/src/FormFields/CoordinatesHandler.php
@@ -2,7 +2,7 @@
 
 namespace TCG\Voyager\FormFields;
 
-class CoordinatesHandler  extends AbstractHandler
+class CoordinatesHandler extends AbstractHandler
 {
     protected $codename = 'coordinates';
 

--- a/src/FormFields/CoordinatesHandler.php
+++ b/src/FormFields/CoordinatesHandler.php
@@ -4,6 +4,11 @@ namespace TCG\Voyager\FormFields;
 
 class CoordinatesHandler extends AbstractHandler
 {
+    protected $supports = [
+        'mysql',
+        'pgsql',
+    ];
+
     protected $codename = 'coordinates';
 
     public function createContent($row, $dataType, $dataTypeContent, $options)

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -7,9 +7,9 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\DB;
 use Intervention\Image\Constraint;
 use Intervention\Image\Facades\Image;
 use TCG\Voyager\Traits\AlertsMessages;
@@ -336,7 +336,10 @@ abstract class Controller extends BaseController
                 if (empty($coordinates = $request->input($row->field))) {
                     $content = null;
                 } else {
-                    $content = DB::raw('GeomFromText("POINT(' . $coordinates['lat'] . ' '. $coordinates['lng'] . ')")');
+                    //DB::connection()->getPdo()->quote won't work as it quotes the lat/lng, which leads to wrong Geometry type in POINT() MySQL constructor
+                    $lat = (float)($coordinates['lat']);
+                    $lng = (float)($coordinates['lng']);
+                    $content = DB::raw('GeomFromText("POINT('.$lat.' '.$lng.')")');
                 }
                 break;
 

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 use Intervention\Image\Constraint;
 use Intervention\Image\Facades\Image;
 use TCG\Voyager\Traits\AlertsMessages;
@@ -329,6 +330,16 @@ abstract class Controller extends BaseController
                     }
                 }
                 break;
+
+            /********** COORDINATES TYPE **********/
+            case 'coordinates':
+                if (empty($coordinates = $request->input($row->field))) {
+                    $content = null;
+                } else {
+                    $content = DB::raw('GeomFromText("POINT(' . $coordinates['lat'] . ' '. $coordinates['lng'] . ')")');
+                }
+                break;
+
 
             /********** ALL OTHER TEXT TYPE **********/
             default:

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -336,9 +336,10 @@ abstract class Controller extends BaseController
                 if (empty($coordinates = $request->input($row->field))) {
                     $content = null;
                 } else {
-                    //DB::connection()->getPdo()->quote won't work as it quotes the lat/lng, which leads to wrong Geometry type in POINT() MySQL constructor
-                    $lat = (float)($coordinates['lat']);
-                    $lng = (float)($coordinates['lng']);
+                    //DB::connection()->getPdo()->quote won't work as it quotes the
+                    // lat/lng, which leads to wrong Geometry type in POINT() MySQL constructor
+                    $lat = (float) ($coordinates['lat']);
+                    $lng = (float) ($coordinates['lng']);
                     $content = DB::raw('GeomFromText("POINT('.$lat.' '.$lng.')")');
                 }
                 break;

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -344,7 +344,6 @@ abstract class Controller extends BaseController
                 }
                 break;
 
-
             /********** ALL OTHER TEXT TYPE **********/
             default:
                 $value = $request->input($row->field);

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -340,7 +340,7 @@ abstract class Controller extends BaseController
                     // lat/lng, which leads to wrong Geometry type in POINT() MySQL constructor
                     $lat = (float) ($coordinates['lat']);
                     $lng = (float) ($coordinates['lng']);
-                    $content = DB::raw('GeomFromText("POINT('.$lat.' '.$lng.')")');
+                    $content = DB::raw('ST_GeomFromText(\'POINT('.$lat.' '.$lng.')\')');
                 }
                 break;
 

--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace TCG\Voyager\Traits;
+
+use Illuminate\Support\Facades\DB;
+
+trait Spatial
+{
+    /**
+     * Get a new query builder for the model's table.
+     * Manipulate in case we need to convert geometrical fields to text.
+     *
+     * @param  bool  $excludeDeleted
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function newQuery($excludeDeleted = true) {
+        if (!empty($this->spatial)) {
+            $raw = '';
+            foreach ($this->spatial as $column) {
+                $raw .= 'AsText(`' . $this->table . '`.`' . $column . '`) as `' . $column . '`, ';
+            }
+            $raw = substr($raw, 0, -2);
+            return parent::newQuery($excludeDeleted)->addSelect('*', DB::raw($raw));
+        }
+        return parent::newQuery($excludeDeleted);
+    }
+
+    /**
+     * Format and return array of (lat,lng) pairs of points fetched from the database
+     *
+     * @return array $coords
+     */
+    public function getCoordinates() {
+        $coords = array();
+
+        if (!empty($this->spatial)) {
+            foreach ($this->spatial as $column) {
+                $clear = trim(preg_replace('/[a-zA-Z\(\)]/','',$this->$column));
+                if(!empty($clear)) {
+                    foreach(explode(',',$clear) as $point) {
+                        list($lat, $lng) = explode(' ', $point);
+                        $coords[] = array(
+                            'lat' => $lat,
+                            'lng' => $lng,
+                        );
+                    }
+                }
+            }
+        }
+
+        return $coords;
+    }
+}

--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -10,14 +10,15 @@ trait Spatial
      * Get a new query builder for the model's table.
      * Manipulate in case we need to convert geometrical fields to text.
      *
-     * @param  bool  $excludeDeleted
+     * @param bool $excludeDeleted
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function newQuery($excludeDeleted = true) {
+    public function newQuery($excludeDeleted = true)
+    {
         if (!empty($this->spatial)) {
             $raw = '';
             foreach ($this->spatial as $column) {
-                $raw .= 'AsText(`' . $this->table . '`.`' . $column . '`) as `' . $column . '`, ';
+                $raw .= 'AsText(`'.$this->table.'`.`'.$column.'`) as `'.$column.'`, ';
             }
             $raw = substr($raw, 0, -2);
             return parent::newQuery($excludeDeleted)->addSelect('*', DB::raw($raw));
@@ -26,23 +27,24 @@ trait Spatial
     }
 
     /**
-     * Format and return array of (lat,lng) pairs of points fetched from the database
+     * Format and return array of (lat,lng) pairs of points fetched from the database.
      *
      * @return array $coords
      */
-    public function getCoordinates() {
-        $coords = array();
+    public function getCoordinates()
+    {
+        $coords = [];
 
         if (!empty($this->spatial)) {
             foreach ($this->spatial as $column) {
-                $clear = trim(preg_replace('/[a-zA-Z\(\)]/','',$this->$column));
-                if(!empty($clear)) {
-                    foreach(explode(',',$clear) as $point) {
+                $clear = trim(preg_replace('/[a-zA-Z\(\)]/', '', $this->$column));
+                if (!empty($clear)) {
+                    foreach (explode(',', $clear) as $point) {
                         list($lat, $lng) = explode(' ', $point);
-                        $coords[] = array(
+                        $coords[] = [
                             'lat' => $lat,
                             'lng' => $lng,
-                        );
+                        ];
                     }
                 }
             }

--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -19,7 +19,7 @@ trait Spatial
         if (!empty($this->spatial)) {
             $raw = '';
             foreach ($this->spatial as $column) {
-                $raw .= 'AsText(`'.$this->table.'`.`'.$column.'`) as `'.$column.'`, ';
+                $raw .= 'ST_AsText(' . $column . ') AS ' . $column . ', ';
             }
             $raw = substr($raw, 0, -2);
 

--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -11,6 +11,7 @@ trait Spatial
      * Manipulate in case we need to convert geometrical fields to text.
      *
      * @param bool $excludeDeleted
+     *
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function newQuery($excludeDeleted = true)
@@ -21,8 +22,10 @@ trait Spatial
                 $raw .= 'AsText(`'.$this->table.'`.`'.$column.'`) as `'.$column.'`, ';
             }
             $raw = substr($raw, 0, -2);
+
             return parent::newQuery($excludeDeleted)->addSelect('*', DB::raw($raw));
         }
+
         return parent::newQuery($excludeDeleted);
     }
 

--- a/src/Traits/Spatial.php
+++ b/src/Traits/Spatial.php
@@ -19,7 +19,7 @@ trait Spatial
         if (!empty($this->spatial)) {
             $raw = '';
             foreach ($this->spatial as $column) {
-                $raw .= 'ST_AsText(' . $column . ') AS ' . $column . ', ';
+                $raw .= 'ST_AsText('.$column.') AS '.$column.', ';
             }
             $raw = substr($raw, 0, -2);
 

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -257,7 +257,7 @@ class VoyagerServiceProvider extends ServiceProvider
             'text_area',
             'timestamp',
             'hidden',
-            'coordinates'
+            'coordinates',
         ];
 
         foreach ($formFields as $formField) {

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -257,6 +257,7 @@ class VoyagerServiceProvider extends ServiceProvider
             'text_area',
             'timestamp',
             'hidden',
+            'coordinates'
         ];
 
         foreach ($formFields as $formField) {


### PR DESCRIPTION
# Setup:

- Install Voyager. 

- Create a table with at least one column with any of Geometry datatype (currently only POINT supported). Select "Generate Model" for the table

- Create BREAD for the newly created table. For the Geometry column select 'coordinates' field type. Don't forget to allow all actions for the column under Main menu -> Roles.

- Add the following trait to your model class:

```
use TCG\Voyager\Traits\Spatial;

class Mymodel extends Model
{
    protected $spatial = ['coords'];

    use Spatial;
}
```

where `coords` is the name of your Geometry field you added on step 2. 

- Add Google maps config section in your .env file with the following keys:

```
GOOGLE_MAPS_KEY=AIXXXXXXXXXXXXXXXXXXXXXXXXXqjrA
GOOGLE_MAPS_DEFAULT_CENTER_LAT=50.3083568
GOOGLE_MAPS_DEFAULT_CENTER_LNG=8.2091757
GOOGLE_MAPS_DEFAULT_ZOOM=11
```

obviously, replacing center coordinates and the zoom level with the values for your needs

# Browse:

Navigate to the browse url of your BREAD entity , you will see the coordinates in POINT() constructor in the corresponding column

# Add/Edit:

if you click Edit link of any instance you will see a Google map with a draggable marker , you can drag and release and click Save and the new coordinates will be stored in the database

# Read:

if you click View link of any instance you will see a Google map with a non-draggable marker. Quite similar to the Edit portion, but you can't move it and save
