### PR TITLE
Select query scopes

### DIFF
--- a/resources/views/formfields/select_dropdown.blade.php
+++ b/resources/views/formfields/select_dropdown.blade.php
@@ -31,12 +31,30 @@
                 $relationshipClass = $dataTypeContent->{camel_case($row->field)}()->getRelated();
                 if (isset($options->relationship->where)) {
                     $relationshipOptions = $relationshipClass::where(
-                        $options->relationship->where[0],
-                        $options->relationship->where[1]
+                            $options->relationship->where[0],
+                            $options->relationship->where[1]
                     )->get();
-                } else {
+                } elseif (isset($options->relationship->scopes)) {
+
                     $relationshipOptions = $relationshipClass::all();
-                }
+                    foreach ($options->relationship->scopes as $scope)
+                    {
+                        $scopeParameters = explode(",",$scope);
+
+                        $dynamicScope = count($scopeParameters) > 1 ? true : false;
+                        $scopeName = camel_case($scopeParameters[0]);
+                        if ($dynamicScope) {
+                            $scopeVal = camel_case($scopeParameters[1]);
+                            $relationshipOptions = $relationshipOptions->intersect($relationshipClass::{$scopeName}($scopeVal)->get());
+
+                        } else {
+                            $relationshipOptions = $relationshipOptions->intersect($relationshipClass::{$scopeName}()->get());
+
+                        }
+                    }
+                } else {
+                        $relationshipOptions = $relationshipClass::all();
+                }                
             }
 
             // Try to get default value for the relationship


### PR DESCRIPTION
Hi, As we talked in the #1409 pull, I add the scope options on the selects, in both, dropdown and multiple.
I do not know if it is the best way to do it, but I found it practice. 

This also serves for dynamic scopes.

On the bread you can put
```
{
    "relationship": {
        "key": "id",
        "label": "name",
        "scopes": [
            "currency"
        ]
    }
}
```
or, if you want to use dynamic scope,
```
{
    "relationship": {
        "key": "id",
        "label": "name",
        "scopes": [
            "currency,5"
        ]
    }
}
```
where currency is the name of the scope and 5 is the parameter.

The query may be
`relationshipClass::currency(5)...`

You can also pass more than 1 scope
```
{
    "relationship": {
        "key": "id",
        "label": "name",
        "scopes": [
            "currency,5",
            "active"
        ]
    }
}
```
and again your query:
`relationshipClass::currency(5)->active()...`


I hope it is useful

Regards!.
