### PR TITLE
Switched dimmer text to use unescaped braces.

### DIFF
--- a/resources/views/dimmer.blade.php
+++ b/resources/views/dimmer.blade.php
@@ -2,8 +2,8 @@
     <div class="dimmer"></div>
     <div class="panel-content">
         @if (isset($icon))<i class='{{ $icon }}'></i>@endif
-        <h4>{{ $title }}</h4>
-        <p>{{ $text }}</p>
-        <a href="{{ $button['link'] }}" class="btn btn-primary">{{ $button['text'] }}</a>
+        <h4>{!! $title !!}</h4>
+        <p>{!! $text !!}</p>
+        <a href="{{ $button['link'] }}" class="btn btn-primary">{!! $button['text'] !!}</a>
     </div>
 </div>


### PR DESCRIPTION
Escaped braces are basically to escape the data sent out by the user. Here the data is generally from the database like statistics etc.

There are scenarios where you might want to use html tags in dimmers. For example:

- `<strong>` etc tags.
- `<div>` tags to add classes or IDs.
- `<span class="fa fa-abc">` tags for Font Awesome or similar libraries.

Only these scenarios are on the top of my mind right now, there may be more.