### PR TITLE
Support of multiple file upload. As requested in #595

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -88,7 +88,10 @@
                                             @elseif($row->type == 'file' && !empty($data->{$row->field}) )
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
                                                 @foreach(json_decode($data->{$row->field}) as $file)
-                                                    <a href="/storage/{{ $file->download_link or '' }}">{{ $file->original_name or '' }}</a><br/>
+                                                    <a href="/storage/{{ $file->download_link or '' }}">
+                                                        {{ $file->original_name or '' }}
+                                                    </a>
+                                                    <br/>
                                                 @endforeach
                                             @elseif($row->type == 'rich_text_box')
                                                 @include('voyager::multilingual.input-hidden-bread-browse')

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -87,13 +87,18 @@
                                                 <div class="readmore">{{ strlen( $data->{$row->field} ) > 200 ? substr($data->{$row->field}, 0, 200) . ' ...' : $data->{$row->field} }}</div>
                                             @elseif($row->type == 'file' && !empty($data->{$row->field}) )
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
-                                                @foreach(json_decode($data->{$row->field}) as $file)
-                                                    <a href="/storage/{{ $file->download_link or '' }}">
-                                                        {{ $file->original_name or '' }}
+                                                @if(json_decode($data->{$row->field}))
+                                                    @foreach(json_decode($data->{$row->field}) as $file)
+                                                        <a href="/storage/{{ $file->download_link or '' }}">
+                                                            {{ $file->original_name or '' }}
+                                                        </a>
+                                                        <br/>
+                                                    @endforeach
+                                                @else
+                                                    <a href="/storage/{{ $data->{$row->field} }}">
+                                                        Download
                                                     </a>
-                                                    <br/>
-                                                @endforeach
-                                            @elseif($row->type == 'rich_text_box')
+                                                @endif                                            @elseif($row->type == 'rich_text_box')
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
                                                 <div class="readmore">{{ strlen( strip_tags($data->{$row->field}, '<b><i><u>') ) > 200 ? substr(strip_tags($data->{$row->field}, '<b><i><u>'), 0, 200) . ' ...' : strip_tags($data->{$row->field}, '<b><i><u>') }}</div>
                                             @else

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -98,7 +98,8 @@
                                                     <a href="/storage/{{ $data->{$row->field} }}">
                                                         Download
                                                     </a>
-                                                @endif                                            @elseif($row->type == 'rich_text_box')
+                                                @endif
+                                            @elseif($row->type == 'rich_text_box')
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
                                                 <div class="readmore">{{ strlen( strip_tags($data->{$row->field}, '<b><i><u>') ) > 200 ? substr(strip_tags($data->{$row->field}, '<b><i><u>'), 0, 200) . ' ...' : strip_tags($data->{$row->field}, '<b><i><u>') }}</div>
                                             @else

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -87,7 +87,9 @@
                                                 <div class="readmore">{{ strlen( $data->{$row->field} ) > 200 ? substr($data->{$row->field}, 0, 200) . ' ...' : $data->{$row->field} }}</div>
                                             @elseif($row->type == 'file' && !empty($data->{$row->field}) )
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
-                                                <a href="/storage/{{ $data->{$row->field} }}">Download</a>
+                                                @foreach(json_decode($data->{$row->field}) as $file)
+                                                    <a href="/storage/{{ $file->download_link or '' }}">{{ $file->original_name or '' }}</a><br/>
+                                                @endforeach
                                             @elseif($row->type == 'rich_text_box')
                                                 @include('voyager::multilingual.input-hidden-bread-browse')
                                                 <div class="readmore">{{ strlen( strip_tags($data->{$row->field}, '<b><i><u>') ) > 200 ? substr(strip_tags($data->{$row->field}, '<b><i><u>'), 0, 200) . ' ...' : strip_tags($data->{$row->field}, '<b><i><u>') }}</div>

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -88,7 +88,7 @@
                                         <br/>
                                     @endforeach
                                 @else
-                                    <a href="/storage/{{ $data->{$row->field} }}">
+                                    <a href="/storage/{{ $dataTypeContent->{$row->field} }}">
                                         Download
                                     </a>
                                 @endif

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -80,7 +80,7 @@
                                 @include('voyager::multilingual.input-hidden-bread-read')
                                 <p>{{ strip_tags($dataTypeContent->{$row->field}, '<b><i><u>') }}</p>
                             @elseif($row->type == 'file')
-                                @if(json_decode($data->{$row->field}))
+                                @if(json_decode($dataTypeContent->{$row->field}))
                                     @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
                                         <a href="/storage/{{ $file->download_link or '' }}">
                                             {{ $file->original_name or '' }}

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -80,12 +80,18 @@
                                 @include('voyager::multilingual.input-hidden-bread-read')
                                 <p>{{ strip_tags($dataTypeContent->{$row->field}, '<b><i><u>') }}</p>
                             @elseif($row->type == 'file')
-                                @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
-                                    <a href="/storage/{{ $file->download_link or '' }}">
-                                        {{ $file->original_name or '' }}
+                                @if(json_decode($data->{$row->field}))
+                                    @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
+                                        <a href="/storage/{{ $file->download_link or '' }}">
+                                            {{ $file->original_name or '' }}
+                                        </a>
+                                        <br/>
+                                    @endforeach
+                                @else
+                                    <a href="/storage/{{ $data->{$row->field} }}">
+                                        Download
                                     </a>
-                                    <br/>
-                                @endforeach
+                                @endif
                             @else
                                 @include('voyager::multilingual.input-hidden-bread-read')
                                 <p>{{ $dataTypeContent->{$row->field} }}</p>

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -81,7 +81,10 @@
                                 <p>{{ strip_tags($dataTypeContent->{$row->field}, '<b><i><u>') }}</p>
                             @elseif($row->type == 'file')
                                 @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
-                                    <a href="/storage/{{ $file->download_link or '' }}">{{ $file->original_name or '' }}</a><br/>
+                                    <a href="/storage/{{ $file->download_link or '' }}">
+                                        {{ $file->original_name or '' }}
+                                    </a>
+                                    <br/>
                                 @endforeach
                             @else
                                 @include('voyager::multilingual.input-hidden-bread-read')

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -79,6 +79,10 @@
                             @elseif($row->type == 'rich_text_box')
                                 @include('voyager::multilingual.input-hidden-bread-read')
                                 <p>{{ strip_tags($dataTypeContent->{$row->field}, '<b><i><u>') }}</p>
+                            @elseif($row->type == 'file')
+                                @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
+                                    <a href="/storage/{{ $file->download_link or '' }}">{{ $file->original_name or '' }}</a><br/>
+                                @endforeach
                             @else
                                 @include('voyager::multilingual.input-hidden-bread-read')
                                 <p>{{ $dataTypeContent->{$row->field} }}</p>

--- a/resources/views/formfields/file.blade.php
+++ b/resources/views/formfields/file.blade.php
@@ -1,6 +1,10 @@
 @if(isset($dataTypeContent->{$row->field}))
-    @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
-        <br/><a class="fileType" href="/storage/{{ $file->download_link or '' }}"> {{ $file->original_name or '' }} </a>
-    @endforeach
+    @if(json_decode($dataTypeContent->{$row->field}))
+        @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
+            <br/><a class="fileType" href="/storage/{{ $file->download_link or '' }}"> {{ $file->original_name or '' }} </a>
+        @endforeach
+    @else
+        <a class="fileType" href="/storage/{{ $dataTypeContent->{$row->field} }}"> Download </a>
+    @endif
 @endif
 <input @if($row->required == 1) required @endif type="file" name="{{ $row->field }}[]" multiple="multiple">

--- a/resources/views/formfields/file.blade.php
+++ b/resources/views/formfields/file.blade.php
@@ -1,4 +1,6 @@
 @if(isset($dataTypeContent->{$row->field}))
-    <a class="fileType" href="/storage/{{ $dataTypeContent->{$row->field} }}"> {{ __('voyager.generic.download') }} </a>
+    @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
+        <br/><a class="fileType" href="/storage/{{ $file->download_link or '' }}"> {{ $file->original_name or '' }} </a>
+    @endforeach
 @endif
-<input @if($row->required == 1) required @endif type="file" name="{{ $row->field }}">
+<input @if($row->required == 1) required @endif type="file" name="{{ $row->field }}[]" multiple="multiple">

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -148,20 +148,26 @@ abstract class Controller extends BaseController
 
             /********** FILE TYPE **********/
             case 'file':
-                if ($file = $request->file($row->field)) {
-                    $filename = Str::random(20);
-                    $path = $slug.'/'.date('F').date('Y').'/';
-                    $fullPath = $path.$filename.'.'.$file->getClientOriginalExtension();
-                    $request->file($row->field)->storeAs(
-                        $path,
-                        $filename.'.'.$file->getClientOriginalExtension(),
-                        config('voyager.storage.disk', 'public')
-                    );
+                if ($files = $request->file($row->field)) {
+                    $filesPath = [];
+                    foreach ($files as $key => $file) {
+                        $filename = Str::random(20);
+                        $path = $slug . '/' . date('F') . date('Y') . '/';
+                        $fullPath = $path . $filename . '.' . $file->getClientOriginalExtension();
+                        $file->storeAs(
+                            $path,
+                            $filename . '.' . $file->getClientOriginalExtension(),
+                            config('voyager.storage.disk', 'public')
+                        );
+                        array_push($filesPath, [
+                            'download_link' => $path.$filename.'.'.$file->getClientOriginalExtension(),
+                            'original_name' => $file->getClientOriginalName(),
+                        ]);
+                    }
 
-                    return $fullPath;
+                    return json_encode($filesPath);
                 }
             // no break
-
             /********** MULTIPLE IMAGES TYPE **********/
             case 'multiple_images':
                 if ($files = $request->file($row->field)) {

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -152,11 +152,11 @@ abstract class Controller extends BaseController
                     $filesPath = [];
                     foreach ($files as $key => $file) {
                         $filename = Str::random(20);
-                        $path = $slug . '/' . date('F') . date('Y') . '/';
-                        $fullPath = $path . $filename . '.' . $file->getClientOriginalExtension();
+                        $path = $slug.'/'.date('F').date('Y').'/';
+                        $fullPath = $path.$filename.'.'.$file->getClientOriginalExtension();
                         $file->storeAs(
                             $path,
-                            $filename . '.' . $file->getClientOriginalExtension(),
+                            $filename.'.'.$file->getClientOriginalExtension(),
                             config('voyager.storage.disk', 'public')
                         );
                         array_push($filesPath, [

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -296,6 +296,13 @@ class VoyagerBreadController extends Controller
         // Delete Images
         $this->deleteBreadImages($data, $dataType->deleteRows->where('type', 'image'));
 
+        // Delete Files
+        foreach($dataType->deleteRows->where('type', 'file') as $row) {
+            foreach(json_decode($data->{$row->field}) as $file) {
+                $this->deleteFileIfExists($file->download_link);
+            }
+        }
+
         $data = $data->destroy($id)
             ? [
                 'message'    => __('voyager.generic.successfully_deleted')." {$dataType->display_name_singular}",

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -297,8 +297,8 @@ class VoyagerBreadController extends Controller
         $this->deleteBreadImages($data, $dataType->deleteRows->where('type', 'image'));
 
         // Delete Files
-        foreach($dataType->deleteRows->where('type', 'file') as $row) {
-            foreach(json_decode($data->{$row->field}) as $file) {
+        foreach ($dataType->deleteRows->where('type', 'file') as $row) {
+            foreach (json_decode($data->{$row->field}) as $file) {
                 $this->deleteFileIfExists($file->download_link);
             }
         }


### PR DESCRIPTION
As requested in #595:

- Allowing multiple file upload by default. Using the original 'file' type

- saving original filename in json in the DB for better outlook of the download link

- removing files once the entity is deleted
