### PR TITLE
Bug fix for incorrect rows being used

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -221,7 +221,7 @@ class VoyagerBreadController extends Controller
 
         foreach ($dataType->addRows as $key => $row) {
             $details = json_decode($row->details);
-            $dataType->editRows[$key]['col_width'] = isset($details->width) ? $details->width : 100;
+            $dataType->addRows[$key]['col_width'] = isset($details->width) ? $details->width : 100;
         }
 
         // Check if BREAD is Translatable


### PR DESCRIPTION
Inside the `create()` method of the `VoyagerBreadController`, `editRows` was being used inside the forloop for `addRows` instead of the `addRows`itself.