### PR TITLE
Fixing the primary key issue that was introduced after PR 1452

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -136,13 +136,14 @@
                                         </td>
                                     @endforeach
                                     <td class="no-sort no-click" id="bread-actions">
+                                        @php $primaryKey = isset($data->primaryKey) ? $data->primaryKey : $data->id @endphp
                                         @if (Voyager::can('delete_'.$dataType->name))
                                             <a
                                                 href="javascript:;"
                                                 title="{{ __('voyager.generic.delete') }}"
                                                 class="btn btn-sm btn-danger pull-right delete"
-                                                data-id="{{ $data->{$data->primaryKey} }}"
-                                                id="delete-{{ $data->{$data->primaryKey} }}"
+                                                data-id="{{ $primaryKey }}"
+                                                id="delete-{{ $primaryKey }}"
                                             >
                                                 <i class="voyager-trash"></i> <span class="hidden-xs hidden-sm">
                                                     {{ __('voyager.generic.delete') }}
@@ -150,12 +151,12 @@
                                             </a>
                                         @endif
                                         @if (Voyager::can('edit_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $data->{$data->primaryKey}) }}" title="{{ __('voyager.generic.edit') }}" class="btn btn-sm btn-primary pull-right edit">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $primaryKey) }}" title="{{ __('voyager.generic.edit') }}" class="btn btn-sm btn-primary pull-right edit">
                                                 <i class="voyager-edit"></i> <span class="hidden-xs hidden-sm">{{ __('voyager.generic.edit') }}</span>
                                             </a>
                                         @endif
                                         @if (Voyager::can('read_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.show', $data->{$data->primaryKey}) }}" title="{{ __('voyager.generic.view') }}" class="btn btn-sm btn-warning pull-right">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.show', $primaryKey) }}" title="{{ __('voyager.generic.view') }}" class="btn btn-sm btn-warning pull-right">
                                                 <i class="voyager-eye"></i> <span class="hidden-xs hidden-sm">{{ __('voyager.generic.view') }}</span>
                                             </a>
                                         @endif

--- a/resources/views/menus/browse.blade.php
+++ b/resources/views/menus/browse.blade.php
@@ -44,18 +44,19 @@
                                     </td>
                                     @endforeach
                                     <td class="no-sort no-click">
+                                        @php $primaryKey = isset($data->primaryKey) ? $data->primaryKey : $data->id @endphp
                                         @if (Voyager::can('delete_'.$dataType->name))
-                                            <div class="btn-sm btn-danger pull-right delete" data-id="{{ $data->{$data->primaryKey} }}">
+                                            <div class="btn-sm btn-danger pull-right delete" data-id="{{ $primaryKey }}">
                                                 <i class="voyager-trash"></i> {{ __('voyager.generic.delete') }}
                                             </div>
                                         @endif
                                         @if (Voyager::can('edit_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $data->{$data->primaryKey}) }}" class="btn-sm btn-primary pull-right edit">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $primaryKey) }}" class="btn-sm btn-primary pull-right edit">
                                                 <i class="voyager-edit"></i> {{ __('voyager.generic.edit') }}
                                             </a>
                                         @endif
                                         @if (Voyager::can('edit_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.builder', $data->{$data->primaryKey}) }}" class="btn-sm btn-success pull-right">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.builder', $primaryKey) }}" class="btn-sm btn-success pull-right">
                                                 <i class="voyager-list"></i> {{ __('voyager.generic.builder') }}
                                             </a>
                                         @endif

--- a/resources/views/posts/browse.blade.php
+++ b/resources/views/posts/browse.blade.php
@@ -68,18 +68,19 @@
                                     </td>
                                     @endforeach
                                     <td class="no-sort no-click">
+                                        @php $primaryKey = isset($data->primaryKey) ? $data->primaryKey : $data->id @endphp
                                         @if (Voyager::can('delete_'.$dataType->name))
-                                            <div class="btn-sm btn-danger pull-right delete" data-id="{{ $data->{$data->primaryKey} }}">
+                                            <div class="btn-sm btn-danger pull-right delete" data-id="{{ $primaryKey }}">
                                                 <i class="voyager-trash"></i> {{ __('voyager.generic.delete') }}
                                             </div>
                                         @endif
                                         @if (Voyager::can('edit_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $data->{$data->primaryKey}) }}" class="btn-sm btn-primary pull-right edit">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $primaryKey) }}" class="btn-sm btn-primary pull-right edit">
                                                 <i class="voyager-edit"></i> {{ __('voyager.generic.edit') }}
                                             </a>
                                         @endif
                                         @if (Voyager::can('read_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.show', $data->{$data->primaryKey}) }}" class="btn-sm btn-warning pull-right">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.show', $primaryKey) }}" class="btn-sm btn-warning pull-right">
                                                 <i class="voyager-eye"></i> {{ __('voyager.generic.view') }}
                                             </a>
                                         @endif

--- a/resources/views/users/browse.blade.php
+++ b/resources/views/users/browse.blade.php
@@ -41,18 +41,19 @@
                                     </td>
                                     <td>{{ $data->role ? $data->role->display_name : '' }}</td>
                                     <td class="no-sort no-click">
+                                        @php $primaryKey = isset($data->primaryKey) ? $data->primaryKey : $data->id @endphp
                                         @if (Voyager::can('delete_'.$dataType->name))
-                                            <div class="btn-sm btn-danger pull-right delete" data-id="{{ $data->{$data->primaryKey} }}" id="delete-{{ $data->{$data->primaryKey} }}">
+                                            <div class="btn-sm btn-danger pull-right delete" data-id="{{ $primaryKey }}" id="delete-{{ $primaryKey }}">
                                                 <i class="voyager-trash"></i> {{ __('voyager.generic.delete') }}
                                             </div>
                                         @endif
                                         @if (Voyager::can('edit_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $data->{$data->primaryKey}) }}" class="btn-sm btn-primary pull-right edit">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.edit', $primaryKey) }}" class="btn-sm btn-primary pull-right edit">
                                                 <i class="voyager-edit"></i> {{ __('voyager.generic.edit') }}
                                             </a>
                                         @endif
                                         @if (Voyager::can('read_'.$dataType->name))
-                                            <a href="{{ route('voyager.'.$dataType->slug.'.show', $data->{$data->primaryKey}) }}" class="btn-sm btn-warning pull-right">
+                                            <a href="{{ route('voyager.'.$dataType->slug.'.show', $primaryKey) }}" class="btn-sm btn-warning pull-right">
                                                 <i class="voyager-eye"></i> {{ __('voyager.generic.view') }}
                                             </a>
                                         @endif


### PR DESCRIPTION
In this PR https://github.com/the-control-group/voyager/pull/1452

A new feature was added that allowed users to specify their own `primaryKey`, this will cause it to break if there is not a `primaryKey` specified.

This PR will default to the `id` if primaryKey is not specified in the model.