### PR TITLE
Fixing error of empty details of multiple_select field in bread

### DIFF
--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -28,7 +28,12 @@
                 <div class="panel panel-bordered" style="padding-bottom:5px;">
                     <!-- form start -->
                     @foreach($dataType->readRows as $row)
-                        @php $rowDetails = json_decode($row->details); @endphp
+                        @php $rowDetails = json_decode($row->details);
+                         if($rowDetails === null){
+                                $rowDetails=new stdClass();
+                                $rowDetails->options=new stdClass();
+                         }
+                        @endphp
 
                         <div class="panel-heading" style="border-bottom:0;">
                             <h3 class="panel-title">{{ $row->display_name }}</h3>


### PR DESCRIPTION
reslove error appear when field of a bread selected as select_dropdown without options in detail with throw exception
`First parameter must either be an object or the name of an existing class`