### PR TITLE
Allow raw select for relationships labels

### DIFF
--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -39,7 +39,11 @@ trait BreadRelationshipParser
 
                 $relationships[$method] = function ($query) use ($relation) {
                     // select only what we need
-                    $query->select($relation->key, $relation->label);
+                    if (isset($relation->selectRaw)) {
+                        $query->selectRaw($relation->selectRaw);
+                    } else {
+                        $query->select($relation->key, $relation->label);
+                    }
                 };
             }
         });


### PR DESCRIPTION
I often find myself wishing I could customize the select statement of a relationship.

**Problem:** displaying member.firstname and member.lastname on a Voyager relationship

**Proposed solution:**
Allow user to provide their own select statement on the relationship details.
```
   "relationship": {
        "method": "member",
        "key": "id",
        "label": "name",
        "selectRaw": "id, CONCAT(firstname, ' ', lastname) AS name"
    },
```

Although I guess this solution would allow users with Database Tool access to perform **SQL injections**.. no?

Happy to hear your thoughts!