### PR TITLE
Fixed translation queried twice

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -107,7 +107,7 @@ trait Translatable
      */
     public function translate($language = null, $fallback = true)
     {
-        if ($this->relationLoaded('translations')) {
+        if (! $this->relationLoaded('translations')) {
             $this->load('translations');
         }
 


### PR DESCRIPTION
Fixed translate() method loading translations twice