### PR TITLE
Add bulk delete feature in browse view

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -2,6 +2,10 @@
 
 @section('page_title','All '.$dataType->display_name_plural)
 
+@section('bulk_actions')
+    @include('voyager::partials.bulk-delete')
+@stop
+
 @section('page_header')
     <h1 class="page-title">
         <i class="{{ $dataType->icon }}"></i> {{ $dataType->display_name_plural }}
@@ -24,6 +28,7 @@
                         <table id="dataTable" class="row table table-hover">
                             <thead>
                                 <tr>
+                                    <th></th>
                                     @foreach($dataType->browseRows as $rows)
                                     <th>{{ $rows->display_name }}</th>
                                     @endforeach
@@ -33,6 +38,9 @@
                             <tbody>
                                 @foreach($dataTypeContent as $data)
                                 <tr>
+                                    <td>
+                                        <input type="checkbox" name="row_id" id="checkbox_{{ $data->id }}" value="{{ $data->id }}">
+                                    </td>
                                     @foreach($dataType->browseRows as $row)
                                         <td>
                                             <?php $options = json_decode($row->details); ?>
@@ -129,6 +137,7 @@
         </div>
     </div>
 
+    {{-- Single delete modal --}}
     <div class="modal modal-danger fade" tabindex="-1" id="delete_modal" role="dialog">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -33,6 +33,11 @@
                     @endif
                 @endfor
             </ol>
+            <ul class="navbar-form navbar-left">
+                <div class="form-group">
+                    @yield('bulk_actions')
+                </div>
+            </ul>
         </div>
         <ul class="nav navbar-nav navbar-right">
             <li class="dropdown profile">

--- a/resources/views/partials/bulk-delete.blade.php
+++ b/resources/views/partials/bulk-delete.blade.php
@@ -1,0 +1,62 @@
+<a class="btn btn-danger" id="bulk_delete_btn"><i class="voyager-trash"></i> Bulk delete</a>
+
+{{-- Bulk delete modal --}}
+<div class="modal modal-danger fade" tabindex="-1" id="bulk_delete_modal" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title"><i class="voyager-trash"></i> Are you sure you want to delete
+                    these {{ strtolower($dataType->display_name_plural) }}?</h4>
+            </div>
+            <div class="modal-body" id="bulk_delete_modal_body">
+            </div>
+            <div class="modal-footer">
+                <form action="{{ route('voyager.'.$dataType->slug.'.index') }}/0" id="bulk_delete_form" method="POST">
+                    {{ method_field("DELETE") }}
+                    {{ csrf_field() }}
+                    <input type="hidden" name="ids" id="bulk_delete_input" value="">
+                    <input type="submit" class="btn btn-danger pull-right delete-confirm"
+                             value="Yes, delete these {{ strtolower($dataType->display_name_plural) }}">
+                </form>
+                <button type="button" class="btn btn-default pull-right" data-dismiss="modal">Cancel</button>
+            </div>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+<script>
+// Bulk delete selectors
+var $bulkDeleteBtn = $('#bulk_delete_btn');
+var $bulkDeleteModal = $('#bulk_delete_modal');
+var $bulkDeleteModalBody = $('#bulk_delete_modal_body');
+var $bulkDeleteInput = $('#bulk_delete_input');
+// Reposition modal to prevent z-index issues
+$bulkDeleteModal.appendTo('body');
+// Bulk delete listener
+$bulkDeleteBtn.click(function () {
+    var ids = [];
+    var $checkedBoxes = $('#dataTable input[type=checkbox]:checked');
+    if ($checkedBoxes.length) {
+        // Reset input value
+        $bulkDeleteInput.val('');
+        // Gather IDs and build modal's message
+        var displayName = $checkedBoxes.length > 1 ? '{{ $dataType->display_name_plural }}' : '{{ $dataType->display_name_singular }}';
+        var html = '<div>You\'re about to delete ' + $checkedBoxes.length + ' ' + displayName;
+        $.each($checkedBoxes, function () {
+            var value = $(this).val();
+            ids.push(value);
+        })
+        html += '</div>';
+        $bulkDeleteModalBody.html(html);
+        // Set input value
+        $bulkDeleteInput.val(ids);
+        // Show modal
+        $bulkDeleteModal.modal('show');
+    } else {
+        // No row selected
+        toastr.warning('You haven\'t selected anything to delete');
+    }
+});
+</script>

--- a/resources/views/posts/browse.blade.php
+++ b/resources/views/posts/browse.blade.php
@@ -2,6 +2,10 @@
 
 @section('page_title','All '.$dataType->display_name_plural)
 
+@section('bulk_actions')
+    @include('voyager::partials.bulk-delete')
+@stop
+
 @section('page_header')
     <h1 class="page-title">
         <i class="voyager-news"></i> {{ $dataType->display_name_plural }}
@@ -24,6 +28,7 @@
                         <table id="dataTable" class="table table-hover">
                             <thead>
                                 <tr>
+                                    <th></th>
                                     @foreach($dataType->browseRows as $row)
                                     <th>{{ $row->display_name }}</th>
                                     @endforeach
@@ -33,6 +38,9 @@
                             <tbody>
                                 @foreach($dataTypeContent as $data)
                                 <tr>
+                                    <td>
+                                        <input type="checkbox" name="row_id" id="checkbox_{{ $data->id }}" value="{{ $data->id }}">
+                                    </td>
                                     @foreach($dataType->browseRows as $row)
                                     <td>
                                         @if($row->type == 'image')

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -303,7 +303,8 @@ class VoyagerBreadController extends Controller
         return redirect()->route("voyager.{$dataType->slug}.index")->with($data);
     }
 
-    protected function cleanup($dataType, $data) {
+    protected function cleanup($dataType, $data)
+    {
         // Delete Translations, if present
         if (is_bread_translatable($data)) {
             $data->deleteAttributeTranslations($data->getTranslatableAttributes());


### PR DESCRIPTION
This is an attempt at bringing bulk delete feature to the browse view.
Most of the additions are placed in a new partial: `resources/views/partials/bulk-delete.blade.php`
The generic `bread.blade.php` template and the one specific to posts had to be slightly modified to add a checkbox to the data rows.
Likewise, some modifications had to be done to the `destroy()` method in `VoyagerBreadController` to handle bulk delete requests.