### PR TITLE
Bulk Delete

### DIFF
--- a/publishable/lang/en/voyager.php
+++ b/publishable/lang/en/voyager.php
@@ -20,6 +20,7 @@ return [
         'auto_increment'         => 'Auto Increment',
         'browse'                 => 'Browse',
         'builder'                => 'Builder',
+        'bulk_delete_confirm'    => 'Yes, Delete These',
         'cancel'                 => 'Cancel',
         'choose_type'            => 'Choose Type',
         'click_here'             => 'Click Here',

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -2,6 +2,10 @@
 
 @section('page_title', __('voyager.generic.viewing').' '.$dataType->display_name_plural)
 
+@section('bulk_actions')
+    @include('voyager::partials.bulk-delete')
+@stop
+
 @section('page_header')
     <h1 class="page-title">
         <i class="{{ $dataType->icon }}"></i> {{ $dataType->display_name_plural }}
@@ -47,6 +51,7 @@
                         <table id="dataTable" class="table table-hover">
                             <thead>
                                 <tr>
+                                    <th></th>
                                     @foreach($dataType->browseRows as $row)
                                     <th>{{ $row->display_name }}</th>
                                     @endforeach
@@ -56,6 +61,9 @@
                             <tbody>
                                 @foreach($dataTypeContent as $data)
                                 <tr>
+                                    <td>
+                                        <input type="checkbox" name="row_id" id="checkbox_{{ $data->id }}" value="{{ $data->id }}">
+                                    </td>
                                     @foreach($dataType->browseRows as $row)
                                         <td>
                                             <?php $options = json_decode($row->details); ?>
@@ -177,6 +185,7 @@
         </div>
     </div>
 
+    {{-- Single delete modal --}}
     <div class="modal modal-danger fade" tabindex="-1" id="delete_modal" role="dialog">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -29,6 +29,11 @@
                     @endif
                 @endfor
             </ol>
+            <ul class="navbar-form navbar-left">
+                <div class="form-group">
+                    @yield('bulk_actions')
+                </div>
+            </ul>
         </div>
         <ul class="nav navbar-nav navbar-right">
             <li class="dropdown profile">

--- a/resources/views/partials/bulk-delete.blade.php
+++ b/resources/views/partials/bulk-delete.blade.php
@@ -1,0 +1,64 @@
+<a class="btn btn-danger" id="bulk_delete_btn"><i class="voyager-trash"></i> Bulk delete</a>
+
+{{-- Bulk delete modal --}}
+<div class="modal modal-danger fade" tabindex="-1" id="bulk_delete_modal" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                            aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title"><i class="voyager-trash"></i> Are you sure you want to delete
+                    these {{ strtolower($dataType->display_name_plural) }}?</h4>
+            </div>
+            <div class="modal-body" id="bulk_delete_modal_body">
+            </div>
+            <div class="modal-footer">
+                <form action="{{ route('voyager.'.$dataType->slug.'.index') }}/0" id="bulk_delete_form" method="POST">
+                    {{ method_field("DELETE") }}
+                    {{ csrf_field() }}
+                    <input type="hidden" name="ids" id="bulk_delete_input" value="">
+                    <input type="submit" class="btn btn-danger pull-right delete-confirm"
+                             value="Yes, delete these {{ strtolower($dataType->display_name_plural) }}">
+                </form>
+                <button type="button" class="btn btn-default pull-right" data-dismiss="modal">Cancel</button>
+            </div>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+<script>
+window.onload = function () {
+    // Bulk delete selectors
+    var $bulkDeleteBtn = $('#bulk_delete_btn');
+    var $bulkDeleteModal = $('#bulk_delete_modal');
+    var $bulkDeleteModalBody = $('#bulk_delete_modal_body');
+    var $bulkDeleteInput = $('#bulk_delete_input');
+    // Reposition modal to prevent z-index issues
+    $bulkDeleteModal.appendTo('body');
+    // Bulk delete listener
+    $bulkDeleteBtn.click(function () {
+        var ids = [];
+        var $checkedBoxes = $('#dataTable input[type=checkbox]:checked');
+        if ($checkedBoxes.length) {
+            // Reset input value
+            $bulkDeleteInput.val('');
+            // Gather IDs and build modal's message
+            var displayName = $checkedBoxes.length > 1 ? '{{ $dataType->display_name_plural }}' : '{{ $dataType->display_name_singular }}';
+            var html = '<div>You\'re about to delete ' + $checkedBoxes.length + ' ' + displayName;
+            $.each($checkedBoxes, function () {
+                var value = $(this).val();
+                ids.push(value);
+            })
+            html += '</div>';
+            $bulkDeleteModalBody.html(html);
+            // Set input value
+            $bulkDeleteInput.val(ids);
+            // Show modal
+            $bulkDeleteModal.modal('show');
+        } else {
+            // No row selected
+            toastr.warning('You haven\'t selected anything to delete');
+        }
+    });
+}
+</script>

--- a/resources/views/partials/bulk-delete.blade.php
+++ b/resources/views/partials/bulk-delete.blade.php
@@ -7,8 +7,9 @@
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
                             aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title"><i class="voyager-trash"></i> Are you sure you want to delete
-                    these {{ strtolower($dataType->display_name_plural) }}?</h4>
+                <h4 class="modal-title">
+                    <i class="voyager-trash"></i> {{ __('voyager.generic.are_you_sure_delete') }} <span id="bulk_delete_count"></span> <span id="bulk_delete_display_name"></span>?
+                </h4>
             </div>
             <div class="modal-body" id="bulk_delete_modal_body">
             </div>
@@ -18,9 +19,11 @@
                     {{ csrf_field() }}
                     <input type="hidden" name="ids" id="bulk_delete_input" value="">
                     <input type="submit" class="btn btn-danger pull-right delete-confirm"
-                             value="Yes, delete these {{ strtolower($dataType->display_name_plural) }}">
+                             value="{{ __('voyager.generic.bulk_delete_confirm') }} {{ strtolower($dataType->display_name_plural) }}">
                 </form>
-                <button type="button" class="btn btn-default pull-right" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-default pull-right" data-dismiss="modal">
+                    {{ __('voyager.generic.cancel') }}
+                </button>
             </div>
         </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
@@ -31,7 +34,8 @@ window.onload = function () {
     // Bulk delete selectors
     var $bulkDeleteBtn = $('#bulk_delete_btn');
     var $bulkDeleteModal = $('#bulk_delete_modal');
-    var $bulkDeleteModalBody = $('#bulk_delete_modal_body');
+    var $bulkDeleteCount = $('#bulk_delete_count');
+    var $bulkDeleteDisplayName = $('#bulk_delete_display_name');
     var $bulkDeleteInput = $('#bulk_delete_input');
     // Reposition modal to prevent z-index issues
     $bulkDeleteModal.appendTo('body');
@@ -39,18 +43,20 @@ window.onload = function () {
     $bulkDeleteBtn.click(function () {
         var ids = [];
         var $checkedBoxes = $('#dataTable input[type=checkbox]:checked');
-        if ($checkedBoxes.length) {
+        var count = $checkedBoxes.length;
+        if (count) {
             // Reset input value
             $bulkDeleteInput.val('');
-            // Gather IDs and build modal's message
-            var displayName = $checkedBoxes.length > 1 ? '{{ $dataType->display_name_plural }}' : '{{ $dataType->display_name_singular }}';
-            var html = '<div>You\'re about to delete ' + $checkedBoxes.length + ' ' + displayName;
+            // Deletion info
+            var displayName = count > 1 ? '{{ $dataType->display_name_plural }}' : '{{ $dataType->display_name_singular }}';
+            displayName = displayName.toLowerCase();
+            $bulkDeleteCount.html(count);
+            $bulkDeleteDisplayName.html(displayName);
+            // Gather IDs
             $.each($checkedBoxes, function () {
                 var value = $(this).val();
                 ids.push(value);
             })
-            html += '</div>';
-            $bulkDeleteModalBody.html(html);
             // Set input value
             $bulkDeleteInput.val(ids);
             // Show modal

--- a/resources/views/posts/browse.blade.php
+++ b/resources/views/posts/browse.blade.php
@@ -2,6 +2,10 @@
 
 @section('page_title', __('voyager.generic.viewing').' '.$dataType->display_name_plural)
 
+@section('bulk_actions')
+    @include('voyager::partials.bulk-delete')
+@stop
+
 @section('page_header')
     <h1 class="page-title">
         <i class="voyager-news"></i> {{ $dataType->display_name_plural }}
@@ -43,6 +47,7 @@
                         <table id="dataTable" class="table table-hover">
                             <thead>
                                 <tr>
+                                    <th></th>
                                     @foreach($dataType->browseRows as $row)
                                     <th>{{ $row->display_name }}</th>
                                     @endforeach
@@ -52,6 +57,9 @@
                             <tbody>
                                 @foreach($dataTypeContent as $data)
                                 <tr>
+                                    <td>
+                                        <input type="checkbox" name="row_id" id="checkbox_{{ $data->id }}" value="{{ $data->id }}">
+                                    </td>
                                     @foreach($dataType->browseRows as $row)
                                     <td>
                                         @if($row->type == 'image')

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -321,7 +321,7 @@ class VoyagerBreadController extends Controller
 
         $displayName = count($ids) > 1 ? $dataType->display_name_plural : $dataType->display_name_singular;
 
-        $data = $data->destroy($id)
+        $data = $data->destroy($ids)
             ? [
                 'message'    => __('voyager.generic.successfully_deleted')." {$displayName}",
                 'alert-type' => 'success',

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -336,10 +336,10 @@ class VoyagerBreadController extends Controller
 
     /**
      * Remove translations, images and files related to a BREAD item.
-     * 
+     *
      * @param \Illuminate\Database\Eloquent\Model $dataType
      * @param \Illuminate\Database\Eloquent\Model $data
-     * 
+     *
      * @return void
      */
     protected function cleanup($dataType, $data)

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -305,8 +305,45 @@ class VoyagerBreadController extends Controller
         $model = $model::where('id', $id)->get();
         $this->authorize('delete', app($dataType->model_name));
 
-        $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
+        // Init array of IDs
+        $ids = [];
+        if (empty($id)) {
+            // Bulk delete, get IDs from POST
+            $ids = explode(',', $request->ids);
+        } else {
+            // Single item delete, get ID from URL
+            $ids[] = $id;
+        }
+        foreach ($ids as $id) {
+            $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
+            $this->cleanup($dataType, $data);
+        }
 
+        $displayName = count($ids) > 1 ? $dataType->display_name_plural : $dataType->display_name_singular;
+        $these = count($ids) > 1 ? 'these' : 'this';
+
+        $data = $data->destroy($ids)
+            ? [
+                'message'    => "Successfully Deleted {$displayName}",
+                'alert-type' => 'success',
+            ]
+            : [
+                'message'    => "Sorry it appears there was a problem deleting {$these} {$displayName}",
+                'alert-type' => 'error',
+            ];
+
+        return redirect()->route("voyager.{$dataType->slug}.index")->with($data);
+    }
+
+    /**
+     * Remove translations, images and files related to a BREAD item.
+     * 
+     * @param \Illuminate\Database\Eloquent\Model $dataType
+     * @param \Illuminate\Database\Eloquent\Model $data
+     * 
+     * @return void
+     */
+    protected function cleanup($dataType, $data) {
         // Delete Translations, if present
         if (is_bread_translatable($data)) {
             $data->deleteAttributeTranslations($data->getTranslatableAttributes());
@@ -321,18 +358,6 @@ class VoyagerBreadController extends Controller
                 $this->deleteFileIfExists($file->download_link);
             }
         }
-
-        $data = $data->destroy($id)
-            ? [
-                'message'    => __('voyager.generic.successfully_deleted')." {$dataType->display_name_singular}",
-                'alert-type' => 'success',
-            ]
-            : [
-                'message'    => __('voyager.generic.error_deleting')." {$dataType->display_name_singular}",
-                'alert-type' => 'error',
-            ];
-
-        return redirect()->route("voyager.{$dataType->slug}.index")->with($data);
     }
 
     /**

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -320,15 +320,14 @@ class VoyagerBreadController extends Controller
         }
 
         $displayName = count($ids) > 1 ? $dataType->display_name_plural : $dataType->display_name_singular;
-        $these = count($ids) > 1 ? 'these' : 'this';
 
-        $data = $data->destroy($ids)
+        $data = $data->destroy($id)
             ? [
-                'message'    => "Successfully Deleted {$displayName}",
+                'message'    => __('voyager.generic.successfully_deleted')." {$displayName}",
                 'alert-type' => 'success',
             ]
             : [
-                'message'    => "Sorry it appears there was a problem deleting {$these} {$displayName}",
+                'message'    => __('voyager.generic.error_deleting')." {$displayName}",
                 'alert-type' => 'error',
             ];
 

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -343,7 +343,8 @@ class VoyagerBreadController extends Controller
      * 
      * @return void
      */
-    protected function cleanup($dataType, $data) {
+    protected function cleanup($dataType, $data)
+    {
         // Delete Translations, if present
         if (is_bread_translatable($data)) {
             $data->deleteAttributeTranslations($data->getTranslatableAttributes());


### PR DESCRIPTION
This is an attempt at bringing a bulk delete feature to the browse view.
Most of the additions are placed in `resources/views/partials/bulk-delete.blade.php`.
`VoyagerBreadController` had to be slightly modified to handle bulk delete requests with multiple IDs.
The `browse.blade.php` templates for generic BREADs and Posts were modified to include the feature.

This adds a checkbox to each row in the browse view, as well as a **Bulk delete** button placed next to the breadcrumb.
![screen shot 2017-08-30 at 9 13 23 am](https://user-images.githubusercontent.com/4895885/29874470-dd0aad12-8d64-11e7-85d6-2e1baf9cf4fc.png)

A confirmation modal, similar to the delete modal, pops-up when clicking on the **Bulk delete** button.
![screen shot 2017-08-30 at 9 13 33 am](https://user-images.githubusercontent.com/4895885/29874374-8b9780cc-8d64-11e7-953f-f07d77eb7611.png)
