### PR TITLE
fix: BREAD fails for custom created_at field.

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -56,7 +56,7 @@ class VoyagerBreadController extends Controller
             }
 
             if ($model->timestamps) {
-                $dataTypeContent = call_user_func([$query->latest(), $getter]);
+                $dataTypeContent = call_user_func([$query->latest($model::CREATED_AT), $getter]);
             } else {
                 $dataTypeContent = call_user_func([$query->with($relationships)->orderBy('id', 'DESC'), $getter]);
             }


### PR DESCRIPTION
My models inherit from an old Symfony application, hence all the names are f-up.