### PR TITLE
Sorting + SSR pagination

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -25,7 +25,7 @@
             <div class="col-md-12">
                 <div class="panel panel-bordered">
                     <div class="panel-body table-responsive">
-                        @if (isset($dataType->server_side) && $dataType->server_side)
+                        @if ($isServerSide)
                             <form method="get">
                                 <div id="search-input">
                                     <select id="search_key" name="key">
@@ -53,7 +53,22 @@
                                 <tr>
                                     <th></th>
                                     @foreach($dataType->browseRows as $row)
-                                    <th>{{ $row->display_name }}</th>
+                                    <th>
+                                        @if ($isServerSide)
+                                            <a href="{{ $row->sortByUrl() }}">
+                                        @endif
+                                        {{ $row->display_name }}
+                                        @if ($isServerSide)
+                                            @if ($row->isCurrentSortField())
+                                                @if (!isset($_GET['sort_order']) || $_GET['sort_order'] == 'asc')
+                                                    <i class="voyager-angle-up pull-right"></i>
+                                                @else
+                                                    <i class="voyager-angle-down pull-right"></i>
+                                                @endif
+                                            @endif
+                                            </a>
+                                        @endif
+                                    </th>
                                     @endforeach
                                     <th class="actions">{{ __('voyager.generic.actions') }}</th>
                                 </tr>
@@ -166,7 +181,7 @@
                                 @endforeach
                             </tbody>
                         </table>
-                        @if (isset($dataType->server_side) && $dataType->server_side)
+                        @if ($isServerSide)
                             <div class="pull-left">
                                 <div role="status" class="show-res" aria-live="polite">{{ trans_choice(
                                     'voyager.generic.showing_entries', $dataTypeContent->total(), [
@@ -176,7 +191,11 @@
                                     ]) }}</div>
                             </div>
                             <div class="pull-right">
-                                {{ $dataTypeContent->appends(['s' => $search])->links() }}
+                                {{ $dataTypeContent->appends([
+                                    's' => $search,
+                                    'order_by' => $orderBy,
+                                    'sort_order' => $sortOrder
+                                ])->links() }}
                             </div>
                         @endif
                     </div>

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -57,13 +57,13 @@ class VoyagerBreadController extends Controller
                 $query->where($search->key, $search_filter, $search_value);
             }
 
-            if ($orderBy && in_array($orderBy, $dataType->fields()))  {
+            if ($orderBy && in_array($orderBy, $dataType->fields())) {
                 $querySortOrder = (!empty($sortOrder)) ? $sortOrder : 'DESC';
                 $dataTypeContent = call_user_func([
                     $query->with($relationships)->orderBy($orderBy, $querySortOrder),
                     $getter
                 ]);
-            } else if ($model->timestamps) {
+            } elseif ($model->timestamps) {
                 $dataTypeContent = call_user_func([$query->latest($model::CREATED_AT), $getter]);
             } else {
                 $dataTypeContent = call_user_func([$query->with($relationships)->orderBy('id', 'DESC'), $getter]);

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -61,7 +61,7 @@ class VoyagerBreadController extends Controller
                 $querySortOrder = (!empty($sortOrder)) ? $sortOrder : 'DESC';
                 $dataTypeContent = call_user_func([
                     $query->with($relationships)->orderBy($orderBy, $querySortOrder),
-                    $getter
+                    $getter,
                 ]);
             } elseif ($model->timestamps) {
                 $dataTypeContent = call_user_func([$query->latest($model::CREATED_AT), $getter]);

--- a/src/Models/DataRow.php
+++ b/src/Models/DataRow.php
@@ -28,4 +28,30 @@ class DataRow extends Model
 
         return @$options->column;
     }
+
+    /**
+     * Check if this field is the current filter
+     * @return boolean True if this is the current filter, false otherwise
+     */
+    public function isCurrentSortField()
+    {
+        return isset($_GET['order_by']) && $_GET['order_by'] == $this->field;
+    }
+
+    /**
+     * Build the URL to sort data type by this field
+     * @return string Built URL
+     */
+    public function sortByUrl()
+    {
+        $params = $_GET;
+        $isDesc = isset($params['sort_order']) && $params['sort_order'] != 'asc';
+        if ($this->isCurrentSortField() && $isDesc) {
+            $params['sort_order'] = 'asc';
+        } else {
+            $params['sort_order'] = 'desc';
+        }
+        $params['order_by'] = $this->field;
+        return url()->current() . '?' . http_build_query($params);
+    }
 }

--- a/src/Models/DataRow.php
+++ b/src/Models/DataRow.php
@@ -31,6 +31,7 @@ class DataRow extends Model
 
     /**
      * Check if this field is the current filter
+     *
      * @return boolean True if this is the current filter, false otherwise
      */
     public function isCurrentSortField()
@@ -40,6 +41,7 @@ class DataRow extends Model
 
     /**
      * Build the URL to sort data type by this field
+     *
      * @return string Built URL
      */
     public function sortByUrl()
@@ -52,6 +54,6 @@ class DataRow extends Model
             $params['sort_order'] = 'desc';
         }
         $params['order_by'] = $this->field;
-        return url()->current() . '?' . http_build_query($params);
+        return url()->current().'?'.http_build_query($params);
     }
 }

--- a/src/Models/DataRow.php
+++ b/src/Models/DataRow.php
@@ -32,7 +32,7 @@ class DataRow extends Model
     /**
      * Check if this field is the current filter.
      *
-     * @return boolean True if this is the current filter, false otherwise
+     * @return bool True if this is the current filter, false otherwise
      */
     public function isCurrentSortField()
     {

--- a/src/Models/DataRow.php
+++ b/src/Models/DataRow.php
@@ -30,7 +30,7 @@ class DataRow extends Model
     }
 
     /**
-     * Check if this field is the current filter
+     * Check if this field is the current filter.
      *
      * @return boolean True if this is the current filter, false otherwise
      */
@@ -40,7 +40,7 @@ class DataRow extends Model
     }
 
     /**
-     * Build the URL to sort data type by this field
+     * Build the URL to sort data type by this field.
      *
      * @return string Built URL
      */
@@ -54,6 +54,7 @@ class DataRow extends Model
             $params['sort_order'] = 'desc';
         }
         $params['order_by'] = $this->field;
+
         return url()->current().'?'.http_build_query($params);
     }
 }


### PR DESCRIPTION
This adds the ability to sort items in server-side rendered lists.

![screen shot 2017-08-31 at 3 54 53 pm](https://user-images.githubusercontent.com/4895885/29943201-9b246066-8e66-11e7-9d6e-f18b019331c7.png)

- [x] When clicking on one of the column's title, the data should be sorted by the corresponding field in descending order
- [x] Every subsequent clicks on the same column's title should reverse the sort order
- [x] Sort order should default to descending if `sortOrder` parameter is missing or equlas anything else than `desc` or `asc`
- [x] Sorting should work well with pagination (ie. changing sorting field while on page 2, or navigating to any page after selecting a sorting field)
- [x] At the moment, performing a search scraps sorting parameters, but search results can then be sorted normally

While working on this, I encountered some issues with the search form and the pagination. It looks like search params are not passed properly to the `appends()` method when displaying the pagination links, I might submit another PR to try addressing this issue.