### PR TITLE
Reposition add and bulk delete buttons

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -2,20 +2,21 @@
 
 @section('page_title', __('voyager.generic.viewing').' '.$dataType->display_name_plural)
 
-@section('bulk_actions')
-    @include('voyager::partials.bulk-delete')
-@stop
-
 @section('page_header')
     <h1 class="page-title">
         <i class="{{ $dataType->icon }}"></i> {{ $dataType->display_name_plural }}
+    </h1>
+    <div class="container-fluid">
         @can('add',app($dataType->model_name))
             <a href="{{ route('voyager.'.$dataType->slug.'.create') }}" class="btn btn-success">
                 <i class="voyager-plus"></i> {{ __('voyager.generic.add_new') }}
             </a>
         @endcan
-    </h1>
-    @include('voyager::multilingual.language-selector')
+        @can('delete',app($dataType->model_name))
+            @include('voyager::partials.bulk-delete')
+        @endcan
+        @include('voyager::multilingual.language-selector')
+    </div>
 @stop
 
 @section('content')

--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -29,11 +29,6 @@
                     @endif
                 @endfor
             </ol>
-            <ul class="navbar-form navbar-left">
-                <div class="form-group">
-                    @yield('bulk_actions')
-                </div>
-            </ul>
         </div>
         <ul class="nav navbar-nav navbar-right">
             <li class="dropdown profile">

--- a/resources/views/posts/browse.blade.php
+++ b/resources/views/posts/browse.blade.php
@@ -2,20 +2,21 @@
 
 @section('page_title', __('voyager.generic.viewing').' '.$dataType->display_name_plural)
 
-@section('bulk_actions')
-    @include('voyager::partials.bulk-delete')
-@stop
-
 @section('page_header')
     <h1 class="page-title">
         <i class="voyager-news"></i> {{ $dataType->display_name_plural }}
+    </h1>
+    <div class="container-fluid">
         @can('add',app($dataType->model_name))
             <a href="{{ route('voyager.'.$dataType->slug.'.create') }}" class="btn btn-success">
                 <i class="voyager-plus"></i> {{ __('voyager.generic.add_new') }}
             </a>
         @endcan
-    </h1>
-    @include('voyager::multilingual.language-selector')
+        @can('delete',app($dataType->model_name))
+            @include('voyager::partials.bulk-delete')
+        @endcan
+        @include('voyager::multilingual.language-selector')
+    </div>
 @stop
 
 @section('content')


### PR DESCRIPTION
Following comments by @fletch3555 (https://github.com/the-control-group/voyager/pull/1620#issuecomment-326385269), here's a PR to reposition the Bulk delete button.
I actually moved both the add and the bulk delete buttons below the title because having them on the same line made it look bad on mobile.

![screen shot 2017-08-31 at 5 07 21 pm](https://user-images.githubusercontent.com/4895885/29945371-e3334392-8e6e-11e7-99d5-f980950394ce.png)

![screen shot 2017-08-31 at 5 07 28 pm](https://user-images.githubusercontent.com/4895885/29945375-e51c75d4-8e6e-11e7-87cf-174d4558ae98.png)

I'm open to suggestions to improve this all.