### PR TITLE
Adding package auto-discovery for Voyager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,12 @@
             "TCG\\Voyager\\Tests\\": "tests/"
       }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "TCG\\Voyager\\VoyagerServiceProvider"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Adding Auto-discovery to Voyager so that way in Laravel 5.5 users will not need to add the Service Provider.