### PR TITLE
change fire to handle

### DIFF
--- a/src/Commands/AdminCommand.php
+++ b/src/Commands/AdminCommand.php
@@ -38,7 +38,7 @@ class AdminCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         // Get or create user
         $user = $this->getUser(

--- a/src/Commands/ControllersCommand.php
+++ b/src/Commands/ControllersCommand.php
@@ -53,7 +53,7 @@ class ControllersCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $stub = $this->getStub();
         $files = $this->filesystem->files(base_path('vendor/tcg/voyager/src/Http/Controllers'));


### PR DESCRIPTION
Since Laravel 5.1 `fire` method is replaced by `handle`. This fixes the commands in the newer versions.

If you want to be backwards compatible, we could create a `handle` method which calls `fire` or the other way around to make sure every laravel version finds the command logic. But i think this is better.