### PR TITLE
remove unnecessary code in template file

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -109,7 +109,7 @@
 
 				@php
 					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
-	            	$selected_values = isset($relationshipData) ? $relationshipData->belongsToMany($options->model, $options->pivot_table)->pluck($options->label)->all() : array(); //{camel_case($row->field)}()->pluck($options->relationship->key)->all() : array();
+	            	$selected_values = isset($relationshipData) ? $relationshipData->belongsToMany($options->model, $options->pivot_table)->pluck($options->label)->all() : array();
 	            @endphp
 
 	            @if($view == 'browse')
@@ -139,7 +139,7 @@
 				<select class="form-control select2" name="{{ $relationshipField }}[]" multiple>
 					
 			            @php 
-			            	$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model)->pluck($options->key)->all() : array(); //{camel_case($row->field)}()->pluck($options->relationship->key)->all() : array(); ?>
+			            	$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model)->pluck($options->key)->all() : array();
 			                $relationshipOptions = app($options->model)->all();
 			            @endphp
 


### PR DESCRIPTION
`//{camel_case    ($row->field)}()->pluck($options->relationship->key)->all() : array(); ?>`
would result an early closed tag for php, makes `$relationshipOptions = app($options->model)->all();` not evaluated, so remove all such commented code in this file.