### PR TITLE
Get datatable options from config file

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -225,11 +225,13 @@
     <script>
         $(document).ready(function () {
             @if (!$dataType->server_side)
-                var table = $('#dataTable').DataTable({
-                    "order": [],
-                    "language": {!! json_encode(__('voyager.datatable'), true) !!}
-                    @if(config('dashboard.data_tables.responsive')), responsive: true @endif
-                });
+                var table = $('#dataTable').DataTable({!! json_encode(
+                    array_merge([
+                        "order" => [],
+                        "language" => __('voyager.datatable'),
+                    ],
+                    config('voyager.dashboard.data_tables'))
+                , true) !!});
             @else
                 $('#search-input select').select2({
                     minimumResultsForSearch: Infinity

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -230,7 +230,7 @@
                         "order" => [],
                         "language" => __('voyager.datatable'),
                     ],
-                    config('voyager.dashboard.data_tables'))
+                    config('voyager.dashboard.data_tables', []))
                 , true) !!});
             @else
                 $('#search-input select').select2({


### PR DESCRIPTION
**Currently**
Datatable options have to be customized by overriding the bread.browse view

**Solution**
Allow options to be loaded from `voyager.dashboard.data_tables` config entry

Plus fix responsive option not working since `config('dashboard.data_tables.responsive')` does not exist.