### PR TITLE
Fix wrong compare type of null value. string instead null given

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -221,11 +221,11 @@ abstract class Controller extends BaseController
                                     $thumb_resize_width = $resize_width;
                                     $thumb_resize_height = $resize_height;
 
-                                    if ($thumb_resize_width != 'null') {
+                                    if ($thumb_resize_width != null) {
                                         $thumb_resize_width = $thumb_resize_width * $scale;
                                     }
 
-                                    if ($thumb_resize_height != 'null') {
+                                    if ($thumb_resize_height != null) {
                                         $thumb_resize_height = $thumb_resize_height * $scale;
                                     }
 
@@ -332,11 +332,11 @@ abstract class Controller extends BaseController
                                 $thumb_resize_width = $resize_width;
                                 $thumb_resize_height = $resize_height;
 
-                                if ($thumb_resize_width != 'null') {
+                                if ($thumb_resize_width != null) {
                                     $thumb_resize_width = $thumb_resize_width * $scale;
                                 }
 
-                                if ($thumb_resize_height != 'null') {
+                                if ($thumb_resize_height != null) {
                                     $thumb_resize_height = $thumb_resize_height * $scale;
                                 }
 


### PR DESCRIPTION
If we dont have `$options->resize->height` param on
https://github.com/the-control-group/voyager/compare/master...dmekhov:master#diff-bf550c9ef0c15a627ba85f6bca552e12L195
`$resize_height` is set to  `null` `$resize_height = null;` and then on https://github.com/the-control-group/voyager/compare/master...dmekhov:master#diff-bf550c9ef0c15a627ba85f6bca552e12L222  `$thumb_resize_height = $resize_height;`

But on https://github.com/the-control-group/voyager/compare/master...dmekhov:master#diff-bf550c9ef0c15a627ba85f6bca552e12L339 we are compare `$thumb_resize_height` with string and we get 0 in `$thumb_resize_height` and than we get `division by 0` error from resize method of Intervention\Image