### PR TITLE
allow empty fields in voyager settings

### DIFF
--- a/src/Http/Controllers/VoyagerSettingsController.php
+++ b/src/Http/Controllers/VoyagerSettingsController.php
@@ -89,7 +89,10 @@ class VoyagerSettingsController extends Controller
                 'group'   => $setting->group,
             ]);
 
-            if ($content === null && isset($setting->value)) {
+            if ($content === null && $setting->type !== 'image') {
+                $content = '';
+            }
+            if ($content === null && $setting->type === 'image') {
                 $content = $setting->value;
             }
 


### PR DESCRIPTION
sometimes we need to save setting field with an empty string or remove a setting value