### PR TITLE
Corrects Laravel version listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ View the Voyager Cheat Sheet: https://voyager-cheatsheet.ulties.com/
 
 <hr>
 
-Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), made for Laravel 5.3.
+Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), made for Laravel 5.5.
 
 After creating your new Laravel application you can include the Voyager package with the following command: 
 


### PR DESCRIPTION
Version 1 of Voyager supports Laravel 5.5.