### PR TITLE
Replaces real domain (admin.com, email.com) with example.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ View the Voyager Cheat Sheet: https://voyager-cheatsheet.ulties.com/
 
 Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), made for Laravel 5.3.
 
-After creating your new Laravel application you can include the Voyager package with the following command: 
+After creating your new Laravel application you can include the Voyager package with the following command:
 
 ```bash
 composer require tcg/voyager
@@ -53,11 +53,11 @@ Add the Voyager service provider to the `config/app.php` file in the `providers`
 'providers' => [
     // Laravel Framework Service Providers...
     //...
-    
+
     // Package Service Providers
     TCG\Voyager\VoyagerServiceProvider::class,
     // ...
-    
+
     // Application Service Providers
     // ...
 ],
@@ -86,7 +86,7 @@ Start up a local development server with `php artisan serve` And, visit [http://
 
 If you did go ahead with the dummy data, a user should have been created for you with the following login credentials:
 
->**email:** `admin@admin.com`   
+>**email:** `admin@example.com`   
 >**password:** `password`
 
 NOTE: Please note that a dummy user is **only** created if there are no current users in your database.

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ If you did not go with the dummy user, you may wish to assign admin privileges t
 This can easily be done by running this command:
 
 ```bash
-php artisan voyager:admin your@email.com
+php artisan voyager:admin example@example.com
 ```
 
 If you did not install the dummy data and you wish to create a new admin user you can pass the `--create` flag, like so:
 
 ```bash
-php artisan voyager:admin your@email.com --create
+php artisan voyager:admin example@example.com --create
 ```
 
 And you will be prompted for the users name and password.

--- a/publishable/database/seeds/UsersTableSeeder.php
+++ b/publishable/database/seeds/UsersTableSeeder.php
@@ -18,7 +18,7 @@ class UsersTableSeeder extends Seeder
 
             User::create([
                 'name'           => 'Admin',
-                'email'          => 'admin@admin.com',
+                'email'          => 'admin@example.com',
                 'password'       => bcrypt('password'),
                 'remember_token' => str_random(60),
                 'role_id'        => $role->id,

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -14,7 +14,7 @@ class LoginTest extends TestCase
     public function testSuccessfulLoginWithDefaultCredentials()
     {
         $this->visit(route('voyager.login'));
-        $this->type('admin@admin.com', 'email');
+        $this->type('admin@example.com', 'email');
         $this->type('password', 'password');
         $this->press(__('voyager.generic.login'));
         $this->seePageIs(route('voyager.dashboard'));

--- a/tests/RolesTest.php
+++ b/tests/RolesTest.php
@@ -24,7 +24,7 @@ class RolesTest extends TestCase
     public function testRoles()
     {
         $this->visit(route('voyager.login'));
-        $this->type('admin@admin.com', 'email');
+        $this->type('admin@example.com', 'email');
         $this->type('password', 'password');
         $this->press(__('voyager.generic.login'));
         $this->seePageIs(route('voyager.dashboard'));

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -23,7 +23,7 @@ class RouteTest extends TestCase
         $this->disableExceptionHandling();
 
         $this->visit(route('voyager.login'));
-        $this->type('admin@admin.com', 'email');
+        $this->type('admin@example.com', 'email');
         $this->type('password', 'password');
         $this->press(__('voyager.generic.login'));
 

--- a/tests/UserProfileTest.php
+++ b/tests/UserProfileTest.php
@@ -64,12 +64,12 @@ class UserProfileTest extends TestCase
              ->click(__('voyager.profile.edit'))
              ->see(__('voyager.profile.edit_user'))
              ->seePageIs($this->editPageForTheCurrentUser)
-             ->type('another@email.com', 'email')
+             ->type('another@example.com', 'email')
              ->press(__('voyager.generic.save'))
              ->seePageIs($this->listOfUsers)
              ->seeInDatabase(
                  'users',
-                 ['email' => 'another@email.com']
+                 ['email' => 'another@example.com']
              );
     }
 
@@ -119,12 +119,12 @@ class UserProfileTest extends TestCase
              ->click(__('voyager.profile.edit'))
              ->see(__('voyager.profile.edit_user'))
              ->seePageIs($editPageForTheCurrentUser)
-             ->type('another@email.com', 'email')
+             ->type('another@example.com', 'email')
              ->press(__('voyager.generic.save'))
              ->seePageIs($this->listOfUsers)
              ->seeInDatabase(
                  'users',
-                 ['email' => 'another@email.com']
+                 ['email' => 'another@example.com']
              );
     }
 


### PR DESCRIPTION
For documentation and dummy accounts a [reserved domain](https://www.iana.org/domains/reserved) should be used, e.g: `example.com`.

> As described in RFC 2606 and RFC 6761, a number of domains such as example.com and example.org are maintained for documentation purposes. These domains may be used as illustrative examples in documents without prior coordination with us. They are not available for registration or transfer.

The use of a real domain ([admin.com](http://admin.com), [email.com](http://email.com)) means that if a malicious actor had control over that domain they could take over accounts, and unintended emails will be sent to that mail server which will be considered spam, which may harm the sender's mail server reputation.