### PR TITLE
Support for POST method in content timestamp. Fixes #1706.

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -366,7 +366,7 @@ abstract class Controller extends BaseController
             /********** TIMESTAMP TYPE **********/
             case 'timestamp':
                 $content = $request->input($row->field);
-                if ($request->isMethod('PUT')) {
+                if (in_array($request->method(), ['PUT', 'POST'])) {
                     if (empty($request->input($row->field))) {
                         $content = null;
                     } else {


### PR DESCRIPTION
Added support for `POST` method when getting the content type of `timestamp`. Prior to this pull request only `PUT` was supported.