### PR TITLE
Fix for #1766

### DIFF
--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -65,6 +65,10 @@ class VoyagerServiceProvider extends ServiceProvider
         if (!$this->app->runningInConsole() || config('app.env') == 'testing') {
             $this->registerAppCommands();
         }
+        
+        if (env('DB_CONNECTION') === 'mysql'){
+            Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'blob');
+        }
     }
 
     /**

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -65,8 +65,8 @@ class VoyagerServiceProvider extends ServiceProvider
         if (!$this->app->runningInConsole() || config('app.env') == 'testing') {
             $this->registerAppCommands();
         }
-        
-        if (env('DB_CONNECTION') === 'mysql'){
+
+        if (env('DB_CONNECTION') === 'mysql') {
             Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'blob');
         }
     }


### PR DESCRIPTION
Not sure I've added this in the right place, or if there are better ways to check the DB connection type, but it fixes an issue that occurs when rolling back the migrations containing enum types on MySQL connections. I have no clue if this could have any side effects, but it seems to work fine.