### PR TITLE
Reducing code duplication and allowing new permissions to be used immediately

### DIFF
--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -11,82 +11,39 @@ class BasePolicy
     use HandlesAuthorization;
 
     /**
-     * Determine if the given user can browse the model.
+     * Handle all requested permission checks
      *
-     * @param \TCG\Voyager\Contracts\User $user
-     * @param  $model
-     *
+     * @param string $name
+     * @param array $arguments
      * @return bool
      */
-    public function browse(User $user, $model)
+    public function __call($name, $arguments)
     {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
+        if (count($arguments) < 2) {
+            throw new \InvalidArgumentException("not enough arguments");
+        }
+        /** @var \TCG\Voyager\Contracts\User $user */
+        $user = $arguments[0];
 
-        return $user->hasPermission('browse_'.$dataType->name);
+        /** @var $model */
+        $model = $arguments[1];
+
+        return $this->checkPermission($user, $model, $name);
     }
 
     /**
-     * Determine if the given model can be viewed by the user.
+     * Check if user has an associated permission
      *
      * @param \TCG\Voyager\Contracts\User $user
-     * @param  $model
-     *
+     * @param object $model
+     * @param string $action
      * @return bool
      */
-    public function read(User $user, $model)
+    protected function checkPermission(User $user, $model, $action)
     {
         $dataType = Voyager::model('DataType');
         $dataType = $dataType->where('model_name', get_class($model))->first();
 
-        return $user->hasPermission('read_'.$dataType->name);
-    }
-
-    /**
-     * Determine if the given model can be edited by the user.
-     *
-     * @param \TCG\Voyager\Contracts\User $user
-     * @param  $model
-     *
-     * @return bool
-     */
-    public function edit(User $user, $model)
-    {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
-
-        return $user->hasPermission('edit_'.$dataType->name);
-    }
-
-    /**
-     * Determine if the given user can create the model.
-     *
-     * @param \TCG\Voyager\Contracts\User $user
-     * @param  $model
-     *
-     * @return bool
-     */
-    public function add(User $user, $model)
-    {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
-
-        return $user->hasPermission('add_'.$dataType->name);
-    }
-
-    /**
-     * Determine if the given model can be deleted by the user.
-     *
-     * @param \TCG\Voyager\Contracts\User $user
-     * @param  $model
-     *
-     * @return bool
-     */
-    public function delete(User $user, $model)
-    {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
-
-        return $user->hasPermission('delete_'.$dataType->name);
+        return $user->hasPermission($action . '_' . $dataType->name);
     }
 }

--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -11,16 +11,17 @@ class BasePolicy
     use HandlesAuthorization;
 
     /**
-     * Handle all requested permission checks
+     * Handle all requested permission checks.
      *
      * @param string $name
-     * @param array $arguments
+     * @param array  $arguments
+     *
      * @return bool
      */
     public function __call($name, $arguments)
     {
         if (count($arguments) < 2) {
-            throw new \InvalidArgumentException("not enough arguments");
+            throw new \InvalidArgumentException('not enough arguments');
         }
         /** @var \TCG\Voyager\Contracts\User $user */
         $user = $arguments[0];
@@ -32,11 +33,12 @@ class BasePolicy
     }
 
     /**
-     * Check if user has an associated permission
+     * Check if user has an associated permission.
      *
      * @param \TCG\Voyager\Contracts\User $user
-     * @param object $model
-     * @param string $action
+     * @param object                      $model
+     * @param string                      $action
+     *
      * @return bool
      */
     protected function checkPermission(User $user, $model, $action)
@@ -44,6 +46,6 @@ class BasePolicy
         $dataType = Voyager::model('DataType');
         $dataType = $dataType->where('model_name', get_class($model))->first();
 
-        return $user->hasPermission($action . '_' . $dataType->name);
+        return $user->hasPermission($action.'_'.$dataType->name);
     }
 }

--- a/src/Policies/PostPolicy.php
+++ b/src/Policies/PostPolicy.php
@@ -3,7 +3,6 @@
 namespace TCG\Voyager\Policies;
 
 use TCG\Voyager\Contracts\User;
-use TCG\Voyager\Facades\Voyager;
 
 class PostPolicy extends BasePolicy
 {
@@ -20,7 +19,7 @@ class PostPolicy extends BasePolicy
         // Does this post belong to the current user?
         $current = $user->id === $model->author_id;
 
-        return $current || $this->checkPermission($user, $model, "read");
+        return $current || $this->checkPermission($user, $model, 'read');
     }
 
     /**
@@ -36,7 +35,7 @@ class PostPolicy extends BasePolicy
         // Does this post belong to the current user?
         $current = $user->id === $model->author_id;
 
-        return $current || $this->checkPermission($user, $model, "edit");
+        return $current || $this->checkPermission($user, $model, 'edit');
     }
 
     /**
@@ -52,6 +51,6 @@ class PostPolicy extends BasePolicy
         // Does this post belong to the current user?
         $current = $user->id === $model->author_id;
 
-        return $current || $this->checkPermission($user, $model, "delete");
+        return $current || $this->checkPermission($user, $model, 'delete');
     }
 }

--- a/src/Policies/PostPolicy.php
+++ b/src/Policies/PostPolicy.php
@@ -17,15 +17,10 @@ class PostPolicy extends BasePolicy
      */
     public function read(User $user, $model)
     {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
-
         // Does this post belong to the current user?
-        $current = $user->id === $model->author_id ? true : false;
+        $current = $user->id === $model->author_id;
 
-        $permission = $user->hasPermission('read_'.$dataType->name);
-
-        return $current || $permission;
+        return $current || $this->checkPermission($user, $model, "read");
     }
 
     /**
@@ -38,15 +33,10 @@ class PostPolicy extends BasePolicy
      */
     public function edit(User $user, $model)
     {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
-
         // Does this post belong to the current user?
-        $current = $user->id === $model->author_id ? true : false;
+        $current = $user->id === $model->author_id;
 
-        $permission = $user->hasPermission('edit_'.$dataType->name);
-
-        return $current || $permission;
+        return $current || $this->checkPermission($user, $model, "edit");
     }
 
     /**
@@ -59,14 +49,9 @@ class PostPolicy extends BasePolicy
      */
     public function delete(User $user, $model)
     {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
-
         // Does this post belong to the current user?
-        $current = $user->id === $model->author_id ? true : false;
+        $current = $user->id === $model->author_id;
 
-        $permission = $user->hasPermission('delete_'.$dataType->name);
-
-        return $current || $permission;
+        return $current || $this->checkPermission($user, $model, "delete");
     }
 }

--- a/src/Policies/SettingPolicy.php
+++ b/src/Policies/SettingPolicy.php
@@ -19,21 +19,53 @@ class SettingPolicy extends BasePolicy
         return $user->hasPermission('browse_settings');
     }
 
+    /**
+     * Determine if the given model can be viewed by the user.
+     *
+     * @param \TCG\Voyager\Contracts\User $user
+     * @param  $model
+     *
+     * @return bool
+     */
     public function read(User $user, $model)
     {
         return $user->hasPermission('read_settings');
     }
 
+    /**
+     * Determine if the given model can be edited by the user.
+     *
+     * @param \TCG\Voyager\Contracts\User $user
+     * @param  $model
+     *
+     * @return bool
+     */
     public function edit(User $user, $model)
     {
         return $user->hasPermission('edit_settings');
     }
 
+    /**
+     * Determine if the given user can create the model.
+     *
+     * @param \TCG\Voyager\Contracts\User $user
+     * @param  $model
+     *
+     * @return bool
+     */
     public function add(User $user, $model)
     {
         return $user->hasPermission('add_settings');
     }
 
+    /**
+     * Determine if the given model can be deleted by the user.
+     *
+     * @param \TCG\Voyager\Contracts\User $user
+     * @param  $model
+     *
+     * @return bool
+     */
     public function delete(User $user, $model)
     {
         return $user->hasPermission('delete_settings');

--- a/src/Policies/UserPolicy.php
+++ b/src/Policies/UserPolicy.php
@@ -17,15 +17,10 @@ class UserPolicy extends BasePolicy
      */
     public function read(User $user, $model)
     {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
+        // Does this post belong to the current user?
+        $current = $user->id === $model->id;
 
-        // Is this the current user's profile?
-        $current = $user->id === $model->id ? true : false;
-
-        $permission = Voyager::can('read_'.$dataType->name);
-
-        return $current || $permission;
+        return $current || $this->checkPermission($user, $model, "read");
     }
 
     /**
@@ -38,14 +33,9 @@ class UserPolicy extends BasePolicy
      */
     public function edit(User $user, $model)
     {
-        $dataType = Voyager::model('DataType');
-        $dataType = $dataType->where('model_name', get_class($model))->first();
+        // Does this post belong to the current user?
+        $current = $user->id === $model->id;
 
-        // Is this the current user's profile?
-        $current = $user->id === $model->id ? true : false;
-
-        $permission = Voyager::can('edit_'.$dataType->name);
-
-        return $current || $permission;
+        return $current || $this->checkPermission($user, $model, "edit");
     }
 }

--- a/src/Policies/UserPolicy.php
+++ b/src/Policies/UserPolicy.php
@@ -3,7 +3,6 @@
 namespace TCG\Voyager\Policies;
 
 use TCG\Voyager\Contracts\User;
-use TCG\Voyager\Facades\Voyager;
 
 class UserPolicy extends BasePolicy
 {
@@ -20,7 +19,7 @@ class UserPolicy extends BasePolicy
         // Does this post belong to the current user?
         $current = $user->id === $model->id;
 
-        return $current || $this->checkPermission($user, $model, "read");
+        return $current || $this->checkPermission($user, $model, 'read');
     }
 
     /**
@@ -36,6 +35,6 @@ class UserPolicy extends BasePolicy
         // Does this post belong to the current user?
         $current = $user->id === $model->id;
 
-        return $current || $this->checkPermission($user, $model, "edit");
+        return $current || $this->checkPermission($user, $model, 'edit');
     }
 }


### PR DESCRIPTION
There have been numerous requests for how to add restrictions around form fields.  This PR allows users to create permissions on the fly and have them just work automatically (as long as they're in the form of `action_model`).  For example, you could add `edit_role_user`, then it should immediately be available as `@can('edit_role', Auth::user())`.