### PR TITLE
Fix: Order menu children by 'order' attribute

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -39,7 +39,9 @@ class Menu extends Model
     {
         // GET THE MENU - sort collection in blade
         $menu = static::where('name', '=', $menuName)
-            ->with('parent_items.children')
+            ->with(['parent_items.children' => function ($q) {
+                $q->orderBy('order');
+            }])
             ->first();
 
         // Check for Menu Existence


### PR DESCRIPTION
Noticed that the order of menu children did not reflect the 'order' field being set by the menu builder. Not the most elegant fix, but it works to ensure that the children retrieved from the `menu()` helper are sorted properly, instead of by their primary key.

I will note that I tried to apply this 'query scope' to the `children()` recursive relationship on the MenuItem model, but it did not affect the render order of the menu items, so I moved it into the `display()` method on the Menu model.