### PR TITLE
Fix belongsToMany formfields names

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -2,7 +2,7 @@
 	
 	@if(class_exists($options->model))
 
-		@php $relationshipField = @$options->column @endphp
+		@php $relationshipField = (@$options->type=="belongsToMany" ? $row->field : @$options->column) @endphp
 
 		@if($options->type == 'belongsTo')
 

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -47,7 +47,7 @@ abstract class Controller extends BaseController
         foreach ($rows as $row) {
             $options = json_decode($row->details);
 
-            if ($row->type == 'relationship') {
+            if ($row->type == 'relationship' && $options->type != 'belongsToMany') {
                 $row->field = @$options->column;
             }
 


### PR DESCRIPTION
Fix issue when you have multiple belongsToMany relationship in the same BREAD, fields have same names "id[]"
So, I think the best way is to use the key of the relationship.