### PR TITLE
Use $model->getKeyName() instead of hard-coded "id" key.

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -66,7 +66,7 @@ class VoyagerBreadController extends Controller
             } elseif ($model->timestamps) {
                 $dataTypeContent = call_user_func([$query->latest($model::CREATED_AT), $getter]);
             } else {
-                $dataTypeContent = call_user_func([$query->with($relationships)->orderBy('id', 'DESC'), $getter]);
+                $dataTypeContent = call_user_func([$query->with($relationships)->orderBy($model->getKeyName(), 'DESC'), $getter]);
             }
 
             // Replace relationships' keys for labels and create READ links if a slug is provided.


### PR DESCRIPTION
Restore [flexible behavior](https://github.com/the-control-group/voyager/blob/10622dc41248ac45747376a873ce3519f92d6f0d/src/Http/Controllers/VoyagerBreadController.php#L48) from v0.11