### PR TITLE
relationship pivot fix

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -139,7 +139,7 @@
 				<select class="form-control select2" name="{{ $relationshipField }}[]" multiple>
 					
 			            @php 
-			            	$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model)->pluck($options->key)->all() : array();
+					$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model, $options->pivot_table)->pluck($options->key)->all() : array();
 			                $relationshipOptions = app($options->model)->all();
 			            @endphp
 

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -84,7 +84,7 @@ abstract class Controller extends BaseController
 
             if ($row->type == 'relationship' && $options->type == 'belongsToMany') {
                 // Only if select_multiple is working with a relationship
-                $multi_select[] = ['model' => $options->model, 'content' => $content];
+                $multi_select[] = ['model' => $options->model, 'content' => $content, 'table' => $options->pivot_table];
             } else {
                 $data->{$row->field} = $content;
             }
@@ -98,7 +98,7 @@ abstract class Controller extends BaseController
         }
 
         foreach ($multi_select as $sync_data) {
-            $data->belongsToMany($sync_data['model'])->sync($sync_data['content']);
+            $data->belongsToMany($sync_data['model'], $sync_data['table'])->sync($sync_data['content']);
         }
 
         return $data;


### PR DESCRIPTION
I have problem with new relationships in 1.0. Then create relationship, I set pivot table, but that value ignored. Then creating new bread element, I have an error: `Table '#table1#_#table2#' doesn't exist `, but in settings there is table `#table2#_#table1#`. In 0.11.14 I could fix it easy:
return $this->belongsToMany(Project::class, '#table2#_#table1#');
in model class.
That solution for 1.0