### PR TITLE
Add nullable belongsTo relationship support

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -1,5 +1,5 @@
 @if(isset($options->model) && isset($options->type))
-	
+
 	@if(class_exists($options->model))
 
 		@php $relationshipField = @$options->column @endphp
@@ -8,7 +8,7 @@
 
 			@if(isset($view) && ($view == 'browse' || $view == 'read'))
 
-				@php 
+				@php
 					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
 					$model = app($options->model);
             		$query = $model::find($relationshipData->{$options->column});
@@ -16,33 +16,38 @@
 
             	@if(isset($query))
 					<p>{{ $query->{$options->label} }}</p>
+				@elseif(isset($options->null))
+				    <p>{{ $options->null }}</p>
 				@else
-					<p>No results</p>
+				    <p>No results.</p>
 				@endif
 
 			@else
-			
-				<select class="form-control select2" name="{{ $relationshipField }}">
-					@php 
-						$model = app($options->model);
-	            		$query = $model::all();
-	            	@endphp
+
+				<select class="form-control select2" name="{{ $relationshipField }}"  @if(isset($options->null)) data-allow-clear="true" data-placeholder="{{ $options->null }}" @endif>
+				    @php
+				        $model = app($options->model);
+				        $query = $model::all();
+				    @endphp
+				    @if(isset($options->null))
+				        <option></option>
+				    @endif
 					@foreach($query as $relationshipData)
 						<option value="{{ $relationshipData->{$options->key} }}" @if($dataTypeContent->{$relationshipField} == $relationshipData->{$options->key}){{ 'selected="selected"' }}@endif>{{ $relationshipData->{$options->label} }}</option>
 					@endforeach
 				</select>
 
 			@endif
-		
+
 		@elseif($options->type == 'hasOne')
 
-			@php 
+			@php
 
 				$relationshipData = (isset($data)) ? $data : $dataTypeContent;
-			
+
 				$model = app($options->model);
         		$query = $model::where($options->column, '=', $relationshipData->id)->first();
-			
+
 			@endphp
 
 			@if(isset($query))
@@ -63,8 +68,8 @@
 
 	            @if($view == 'browse')
 	            	@php
-	            		$string_values = implode(", ", $selected_values); 
-	            		if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; } 
+	            		$string_values = implode(", ", $selected_values);
+	            		if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; }
 	            	@endphp
 	            	@if(empty($selected_values))
 		            	<p>No results</p>
@@ -96,7 +101,7 @@
 							<li>{{ $query_res->{$options->label} }}</li>
 						@endforeach
 					</ul>
-					
+
 				@else
 					<p>No results</p>
 				@endif
@@ -114,8 +119,8 @@
 
 	            @if($view == 'browse')
 	            	@php
-	            		$string_values = implode(", ", $selected_values); 
-	            		if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; } 
+	            		$string_values = implode(", ", $selected_values);
+	            		if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; }
 	            	@endphp
 	            	@if(empty($selected_values))
 		            	<p>No results</p>
@@ -137,8 +142,8 @@
 			@else
 
 				<select class="form-control select2" name="{{ $relationshipField }}[]" multiple>
-					
-			            @php 
+
+			            @php
 			            	$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model)->pluck($options->key)->all() : array();
 			                $relationshipOptions = app($options->model)->all();
 			            @endphp


### PR DESCRIPTION
Currently if you set a belongsTo relationship on a BREAD, then you are forced to select a value in the dropdown.

This PR adds the ability do define a null value on a belongsTo relationship. Let's take an example with `categories`, saying a category can have a parent category (but not required):
- Create the belongsTo relationship with the UI
- On your data_row, in the `details` column, add `"null": "None"` (None or whatever you want) like this : 
```
{"null":"None","model":"TCG\\Voyager\\Models\\Category","table":"categories","type":"belongsTo","column":"parent_id","key":"id","label":"name","pivot_table":"categories","pivot":"0"}
```
- Then when you add/edit a category, you get this:
![capture d ecran 2017-10-01 a 16 13 38](https://user-images.githubusercontent.com/7209163/31055594-75e36b18-a6c5-11e7-8bc9-a74d5c33e42b.png)
- If you select a parent category, you can remove it with the little cross:
![capture d ecran 2017-10-01 a 16 13 25](https://user-images.githubusercontent.com/7209163/31055599-92d61806-a6c5-11e7-8e68-459f899e1f84.png)
- On the browse view, you get this:
![capture d ecran 2017-10-01 a 16 13 02](https://user-images.githubusercontent.com/7209163/31055603-a3cbdbb4-a6c5-11e7-8beb-e499e6d1262f.png)

I think the next step is to give the ability to edit this directly in the Voyager UI.

