### PR TITLE
Trigger fallback when locale value is empty

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -5147,11 +5147,6 @@ float: left;
   margin-left:10px;
 }
 
-.modal-open .select2-container{
-  z-index: 999999 !important;
-  width:100% !important;
-}
-
 .toggle-group .btn, .toggle-group .btn.btn-default{
   padding-bottom:0px;
   margin-top:0px;

--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -175,7 +175,7 @@ trait Translatable
 
         $localeTranslation = $translations->where('locale', $locale)->first();
 
-        if ($localeTranslation) {
+        if ($localeTranslation && !empty($localeTranslation->value)) {
             return [$localeTranslation->value, $locale, true];
         }
 


### PR DESCRIPTION
The translation fallback is only triggered when the translation doesn't exists. With this the locale translation must exists and not be empty.