### PR TITLE
Change section to group

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -220,7 +220,7 @@
         @if(config('voyager.show_dev_tips'))
         <div class="alert alert-info">
             <strong>{{ __('voyager.generic.how_to_use') }}:</strong>
-            <p>{{ __('voyager.settings.usage_help') }} <code>setting('section.key')</code></p>
+            <p>{{ __('voyager.settings.usage_help') }} <code>setting('group.key')</code></p>
         </div>
         @endif
     </div>


### PR DESCRIPTION
In the admin area, setting groups are called groups everywhere, except in the example at the top. This PR will change `section` to `group`