### PR TITLE
added voyagercheckmaintenancemode middleware

### DIFF
--- a/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
+++ b/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace TCG\Voyager\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+
+class VoyagerCheckForMaintenanceMode
+{
+    
+    protected $whitelist = [
+        "voyager.dashboard",
+        "voyager.compass.index",
+        "voyager.compass.post"
+    ];
+    /**
+     * The application implementation.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle($request, Closure $next)
+    {
+
+        
+        if ($this->app->isDownForMaintenance()) {
+            
+            if(!in_array($request->route()->getName(), $this->whitelist)){
+                $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
+
+                throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
+            }
+
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
+++ b/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
@@ -4,15 +4,16 @@ namespace TCG\Voyager\Http\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode;
 
-class VoyagerCheckForMaintenanceMode
+class VoyagerCheckForMaintenanceMode extends CheckForMaintenanceMode
 {
     protected $whitelist = [
         'voyager.dashboard',
         'voyager.compass.index',
         'voyager.compass.post',
     ];
+
     /**
      * The application implementation.
      *
@@ -44,14 +45,14 @@ class VoyagerCheckForMaintenanceMode
      */
     public function handle($request, Closure $next)
     {
+        $response = $next($request);
+        
         if ($this->app->isDownForMaintenance()) {
-            if (!in_array($request->route()->getName(), $this->whitelist)) {
-                $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
-
-                throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
+            if (!in_array($request->route()->getName(), $this->whitelist)){
+                return parent::handle($request, $next);
             }
         }
 
-        return $next($request);
+        return $response;
     }
 }

--- a/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
+++ b/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
@@ -46,9 +46,8 @@ class VoyagerCheckForMaintenanceMode extends CheckForMaintenanceMode
     public function handle($request, Closure $next)
     {
         $response = $next($request);
-        
         if ($this->app->isDownForMaintenance()) {
-            if (!in_array($request->route()->getName(), $this->whitelist)){
+            if (!in_array($request->route()->getName(), $this->whitelist)) {
                 return parent::handle($request, $next);
             }
         }

--- a/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
+++ b/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
@@ -11,7 +11,7 @@ class VoyagerCheckForMaintenanceMode
     protected $whitelist = [
         'voyager.dashboard',
         'voyager.compass.index',
-        'voyager.compass.post'
+        'voyager.compass.post',
     ];
     /**
      * The application implementation.
@@ -24,6 +24,7 @@ class VoyagerCheckForMaintenanceMode
      * Create a new middleware instance.
      *
      * @param \Illuminate\Contracts\Foundation\Application $app
+     *
      * @return void
      */
     public function __construct(Application $app)

--- a/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
+++ b/src/Http/Middleware/VoyagerCheckForMaintenanceMode.php
@@ -3,17 +3,15 @@
 namespace TCG\Voyager\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 
 class VoyagerCheckForMaintenanceMode
 {
-    
     protected $whitelist = [
-        "voyager.dashboard",
-        "voyager.compass.index",
-        "voyager.compass.post"
+        'voyager.dashboard',
+        'voyager.compass.index',
+        'voyager.compass.post'
     ];
     /**
      * The application implementation.
@@ -25,7 +23,7 @@ class VoyagerCheckForMaintenanceMode
     /**
      * Create a new middleware instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
      * @return void
      */
     public function __construct(Application $app)
@@ -36,24 +34,21 @@ class VoyagerCheckForMaintenanceMode
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     *
+     * @return mixed
      */
     public function handle($request, Closure $next)
     {
-
-        
         if ($this->app->isDownForMaintenance()) {
-            
-            if(!in_array($request->route()->getName(), $this->whitelist)){
+            if (!in_array($request->route()->getName(), $this->whitelist)) {
                 $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
 
                 throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
             }
-
         }
 
         return $next($request);


### PR DESCRIPTION
This is a potential solution to #1947

This would require some method of stubbing the Kernel when you install voyager. The kernel would need to register this checkmaintenancemode middleware rather than the default- something like-

    protected $middleware = [
        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
        \App\Http\Middleware\TrimStrings::class,
        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
        \App\Http\Middleware\TrustProxies::class,
    ];

    /**
     * The application's route middleware groups.
     *
     * @var array
     */
    protected $middlewareGroups = [
        'web' => [
            \TCG\Voyager\Http\Middleware\VoyagerCheckForMaintenanceMode::class,
            \App\Http\Middleware\EncryptCookies::class,
            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
            \Illuminate\Session\Middleware\StartSession::class,
            // \Illuminate\Session\Middleware\AuthenticateSession::class,
            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
            \App\Http\Middleware\VerifyCsrfToken::class,
            \Illuminate\Routing\Middleware\SubstituteBindings::class,
        ],

        'api' => [
            'throttle:60,1',
            'bindings',
        ],
    ];

notice how I removed the default checkForMaintenanceMode middleware from the middleware array and added the voyager one to the web group. (It can't be in the middleware group because I need access to the request object). 

Anyway, Is there a way to stub out the Kernel or would that have other potential side affects?

