### PR TITLE
Check if file is uploaded during cleanup

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -374,8 +374,11 @@ class VoyagerBreadController extends Controller
 
         // Delete Files
         foreach ($dataType->deleteRows->where('type', 'file') as $row) {
-            foreach (json_decode($data->{$row->field}) as $file) {
-                $this->deleteFileIfExists($file->download_link);
+            $files = json_decode($data->{$row->field});
+            if($files) {
+                foreach ($files as $file) {
+                    $this->deleteFileIfExists($file->download_link);
+                }
             }
         }
     }

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -375,7 +375,7 @@ class VoyagerBreadController extends Controller
         // Delete Files
         foreach ($dataType->deleteRows->where('type', 'file') as $row) {
             $files = json_decode($data->{$row->field});
-            if($files) {
+            if ($files) {
                 foreach ($files as $file) {
                     $this->deleteFileIfExists($file->download_link);
                 }


### PR DESCRIPTION
If a file field is defined but there are no files uploaded and you want to delete the row an 'invalid argument supplied for foreach' pops up. 
Solution: check if file info field json_decode returns null.