### PR TITLE
Add Events Support

### DIFF
--- a/src/Events/BreadAdded.php
+++ b/src/Events/BreadAdded.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadAdded
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public function __construct(DataType $dataType, $data)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        event(new BreadChanged($dataType, $data, 'Added'));
+    }
+}

--- a/src/Events/BreadChanged.php
+++ b/src/Events/BreadChanged.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadChanged
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public $changeType;
+
+    public function __construct(DataType $dataType, $data, string $changeType)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        $this->changeType = $changeType;
+    }
+}

--- a/src/Events/BreadDataAdded.php
+++ b/src/Events/BreadDataAdded.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadDataAdded
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public function __construct(DataType $dataType, $data)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        event(new BreadDataChanged($dataType, $data, 'Added'));
+    }
+}

--- a/src/Events/BreadDataChanged.php
+++ b/src/Events/BreadDataChanged.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadDataChanged
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public $changeType;
+
+    public function __construct(DataType $dataType, $data, string $changeType)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        $this->changeType = $changeType;
+    }
+}

--- a/src/Events/BreadDataDeleted.php
+++ b/src/Events/BreadDataDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadDataDeleted
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public function __construct(DataType $dataType, $data)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        event(new BreadDataChanged($dataType, $data, 'Deleted'));
+    }
+}

--- a/src/Events/BreadDataUpdated.php
+++ b/src/Events/BreadDataUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadDataUpdated
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public function __construct(DataType $dataType, $data)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        event(new BreadDataChanged($dataType, $data, 'Updated'));
+    }
+}

--- a/src/Events/BreadDeleted.php
+++ b/src/Events/BreadDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadDeleted
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public function __construct(DataType $dataType, $data)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        event(new BreadChanged($dataType, $data, 'Deleted'));
+    }
+}

--- a/src/Events/BreadImagesDeleted.php
+++ b/src/Events/BreadImagesDeleted.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class BreadImagesDeleted
+{
+    use SerializesModels;
+
+    public $data;
+
+    public $images;
+
+    public function __construct($data, $images)
+    {
+        $this->data = $data;
+
+        $this->images = $images;
+    }
+}

--- a/src/Events/BreadUpdated.php
+++ b/src/Events/BreadUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Models\DataType;
+
+class BreadUpdated
+{
+    use SerializesModels;
+
+    public $dataType;
+
+    public $data;
+
+    public function __construct(DataType $dataType, $data)
+    {
+        $this->dataType = $dataType;
+
+        $this->data = $data;
+
+        event(new BreadChanged($dataType, $data, 'Updated'));
+    }
+}

--- a/src/Events/FileDeleted.php
+++ b/src/Events/FileDeleted.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+class FileDeleted
+{
+    public $path;
+
+    public function __construct($path)
+    {
+        $this->path;
+    }
+}

--- a/src/Events/TableAdded.php
+++ b/src/Events/TableAdded.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+use TCG\Voyager\Database\Schema\Table;
+
+class TableAdded
+{
+    use SerializesModels;
+
+    public $table;
+
+    public function __construct(Table $table)
+    {
+        $this->table = $table;
+
+        event(new TableChanged($table->name, 'Added'));
+    }
+}

--- a/src/Events/TableChanged.php
+++ b/src/Events/TableChanged.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class TableChanged
+{
+    use SerializesModels;
+
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Events/TableDeleted.php
+++ b/src/Events/TableDeleted.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class TableDeleted
+{
+    use SerializesModels;
+
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+
+        event(new TableChanged($name, 'Deleted'));
+    }
+}

--- a/src/Events/TableUpdated.php
+++ b/src/Events/TableUpdated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TCG\Voyager\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class TableUpdated
+{
+    use SerializesModels;
+
+    public $name;
+
+    public function __construct(array $name)
+    {
+        $this->name = $name;
+
+        event(new TableChanged($name["name"], 'Updated'));
+    }
+}

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Intervention\Image\Constraint;
 use Intervention\Image\Facades\Image;
+use TCG\Voyager\Events\FileDeleted;
 use TCG\Voyager\Traits\AlertsMessages;
 use Validator;
 
@@ -442,6 +443,7 @@ abstract class Controller extends BaseController
     {
         if (Storage::disk(config('voyager.storage.disk'))->exists($path)) {
             Storage::disk(config('voyager.storage.disk'))->delete($path);
+            event(new FileDeleted($path));
         }
     }
 

--- a/src/Http/Controllers/VoyagerDatabaseController.php
+++ b/src/Http/Controllers/VoyagerDatabaseController.php
@@ -13,6 +13,12 @@ use TCG\Voyager\Database\Schema\Identifier;
 use TCG\Voyager\Database\Schema\SchemaManager;
 use TCG\Voyager\Database\Schema\Table;
 use TCG\Voyager\Database\Types\Type;
+use TCG\Voyager\Events\BreadAdded;
+use TCG\Voyager\Events\BreadDeleted;
+use TCG\Voyager\Events\BreadUpdated;
+use TCG\Voyager\Events\TableAdded;
+use TCG\Voyager\Events\TableDeleted;
+use TCG\Voyager\Events\TableUpdated;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Models\DataRow;
 use TCG\Voyager\Models\DataType;
@@ -39,6 +45,11 @@ class VoyagerDatabaseController extends Controller
         return Voyager::view('voyager::tools.database.index')->with(compact('dataTypes', 'tables'));
     }
 
+    /**
+     * Create database table.
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function create()
     {
         Voyager::canOrFail('browse_database');
@@ -48,6 +59,13 @@ class VoyagerDatabaseController extends Controller
         return Voyager::view('voyager::tools.database.edit-add', compact('db'));
     }
 
+    /**
+     * Store new database table.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function store(Request $request)
     {
         Voyager::canOrFail('browse_database');
@@ -73,6 +91,9 @@ class VoyagerDatabaseController extends Controller
                 }
 
                 Artisan::call('voyager:make:model', $params);
+
+                event(new TableAdded($table));
+
             } elseif (isset($request->create_migration) && $request->create_migration == 'on') {
                 Artisan::call('make:migration', [
                     'name'    => 'create_'.$table->name.'_table',
@@ -88,6 +109,13 @@ class VoyagerDatabaseController extends Controller
         }
     }
 
+    /**
+     * Edit database table.
+     *
+     * @param  string $table
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function edit($table)
     {
         Voyager::canOrFail('browse_database');
@@ -120,6 +148,7 @@ class VoyagerDatabaseController extends Controller
             DatabaseUpdater::update($table);
             // TODO: synch BREAD with Table
             // $this->cleanOldAndCreateNew($request->original_name, $request->name);
+            event(new TableUpdated($table));
         } catch (Exception $e) {
             return back()->with($this->alertException($e))->withInput();
         }
@@ -213,6 +242,7 @@ class VoyagerDatabaseController extends Controller
 
         try {
             SchemaManager::dropTable($table);
+            event(new TableDeleted($table));
 
             return redirect()
                 ->route('voyager.database.index')
@@ -265,9 +295,13 @@ class VoyagerDatabaseController extends Controller
 
         try {
             $dataType = Voyager::model('DataType');
-            $data = $dataType->updateDataType($request->all(), true)
+            $res      = $dataType->updateDataType($request->all(), true);
+            $data     = $res
                 ? $this->alertSuccess(__('voyager.database.success_created_bread'))
                 : $this->alertError(__('voyager.database.error_creating_bread'));
+            if ($res) {
+                event(new BreadAdded($dataType, $data));
+            }
 
             return redirect()->route('voyager.database.index')->with($data);
         } catch (Exception $e) {
@@ -303,9 +337,13 @@ class VoyagerDatabaseController extends Controller
                 ? $dataType->prepareTranslations($request)
                 : [];
 
-            $data = $dataType->updateDataType($request->all(), true)
+            $res  = $dataType->updateDataType($request->all(), true);
+            $data = $res
                 ? $this->alertSuccess(__('voyager.database.success_update_bread', ['datatype' => $dataType->name]))
                 : $this->alertError(__('voyager.database.error_updating_bread'));
+            if ($res) {
+                event(new BreadUpdated($dataType, $data));
+            }
 
             // Save translations if applied
             $dataType->saveTranslations($translations);
@@ -328,9 +366,13 @@ class VoyagerDatabaseController extends Controller
             $dataType->deleteAttributeTranslations($dataType->getTranslatableAttributes());
         }
 
-        $data = Voyager::model('DataType')->destroy($id)
+        $res  = Voyager::model('DataType')->destroy($id);
+        $data = $res
             ? $this->alertSuccess(__('voyager.database.success_remove_bread', ['datatype' => $dataType->name]))
             : $this->alertError(__('voyager.database.error_updating_bread'));
+        if ($res) {
+            event(new BreadDeleted($dataType, $data));
+        }
 
         if (!is_null($dataType)) {
             Voyager::model('Permission')->removeFrom($dataType->name);


### PR DESCRIPTION
(edit)
Adds Event Support to Voyager.
@marktopper is completing tests #1990. This can be used.

Currently is triggering events for the following, (more can be added later):

| Event         | Parameters      | On |
| ------------- |-------------| -----:|
| `BreadAdded` | $dataType, $data |  |
| `BreadUpdated` | $dataType, $data |  |
| `BreadDeleted` | $dataType, $data |  |
| `BreadChanged` | $dataType, $data, $changeType | Bread(Add/Update/Delete) |
| `BreadDataAdded` | $dataType, $data |  |
| `BreadDataUpdated` | $dataType, $data |  |
| `BreadDataDeleted` | $dataType, $data |  |
| `BreadDataChanged` | $dataType, $data, $changeType | BreadData(Add/Update/Delete) |
| `BreadImagesDeleted` | $data, $images |  |
| `FileDeleted` | $path |  |
| `TableAdded` | $table |  |
| `TableUpdated` | $name($array) |  |
| `TableDeleted` | $name(string) |  |
| `TableChanged` | $name(string) |  Table(Add/Update/Delete) |

## How to Use
Please follow the [Laravel documentation](https://laravel.com/docs/master/events#registering-event-subscribers). You can use it by creating your own Listeners, or by listening to a given event at the boot section of the `EventServiceProvider`.


## Example Listening to `BreadDataChanged`

On your `EventServiceProvider`, on the boot() method.
```
    /**
     * Register any events for your application.
     *
     * @return void
     */
    public function boot()
    {
        parent::boot();

        Event::listen('TCG\Voyager\Events\BreadDataChanged', function (...$args) {
            // Write some logic here
            // ------------------------------------
            // $args->dataType    ---> TCG\Voyager\Models\DataType
            // $args->data        ---> (Object) Data changed
            // $args->changeType  ---> (String) Added|Updated|Deleted
        });
    }
```

Happy coding!