### PR TITLE
Create BREAD (migration, seed and model) files using artisan

### DIFF
--- a/src/Commands/BreadGenerator.php
+++ b/src/Commands/BreadGenerator.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace TCG\Voyager\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+
+class BreadGenerator extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'voyager:bread {name}
+                            {--migration : creates a new migration for this bread}
+                            {--model : creates a new model for this bread}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Bread';
+
+    /**
+     * Execute the console command.
+     * @return mixed
+     */
+    public function handle()
+    {
+        $seederName = Str::studly(Str::plural($this->argument('name')).'BreadSeeder');
+        $this->info('Making BREAD');
+
+        parent::handle();
+
+        if ($this->option('migration')) {
+            $this->createMigration();
+        }
+
+        if ($this->option('model')) {
+            $this->createModel();
+        }
+
+        $this->info('You are almost ready: ');
+        $this->info("1. Once you finish the seed configuration, you need to run : php artisan db:seed --class={$seederName}");
+        $this->info('2. Optionally you may want to re-generate the permissions with: php artisan db:seed --class=PermissionRoleTableSeeder');
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+        return $this->replacePlaceholders($stub)->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Replace placeholder text in the stub file
+     *
+     * @param  string &$stub
+     * @return $this
+     */
+    public function replacePlaceholders(&$stub)
+    {
+        $name = $this->argument('name');
+        $replacements = collect([
+            'DummyStudlyCaseSingular' => Str::studly($name),
+            'DummyStudlyCasePlural' => Str::plural(Str::studly($name)),
+            'DummySnakeCaseSingular' => Str::snake($name),
+            'DummySnakeCasePlural' => Str::plural(Str::snake($name))
+        ]);
+        foreach ($replacements as $placeholder => $replacement) {
+            $stub = str_replace($placeholder, $replacement, $stub);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
+
+        return  base_path('database/seeds').'/'.str_replace('\\', '/', Str::plural($name)).'BreadSeeder.php';
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return trim(studly_case($this->argument('name')));
+    }
+
+    /**
+     * Create a migration file for the model.
+     *
+     * @return void
+     */
+    protected function createMigration()
+    {
+        $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
+
+        $this->call('make:migration', [
+            'name' => "create_{$table}_table",
+            '--create' => $table,
+        ]);
+    }
+
+    /**
+     * Create a model.
+     *
+     * @return void
+     */
+    protected function createModel()
+    {
+        $table = studly_case($this->argument('name'));
+        $this->call('make:model', [
+            'name' => $table
+        ]);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return base_path('vendor/tcg/voyager/stubs/bread.stub');
+    }
+}

--- a/src/Traits/BreadSeeder.php
+++ b/src/Traits/BreadSeeder.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace TCG\Voyager\Traits;
+
+use TCG\Voyager\Models\Menu;
+use TCG\Voyager\Models\DataRow;
+use TCG\Voyager\Models\DataType;
+use TCG\Voyager\Models\MenuItem;
+use TCG\Voyager\Models\Permission;
+
+trait BreadSeeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->createDataType();
+        $this->createInputFields();
+        $this->createMenuItem();
+        $this->generatePermissions();
+    }
+
+    /**
+     * Create a new data-type for the current bread
+     *
+     * @return void
+     */
+    public function createDataType()
+    {
+        $dataType = $this->dataType('slug', $this->bread()['name']);
+        if (!$dataType->exists) {
+            $dataType->fill($this->bread())->save();
+        }
+    }
+
+    /**
+     * Create all the input fields specified in the
+     * bread() method
+     *
+     * @return [type] [description]
+     */
+    public function createInputFields()
+    {
+        $productDataType = DataType::where('slug', $this->bread()['name'])->firstOrFail();
+
+        collect($this->inputFields())->each(function ($field, $key) use ($productDataType) {
+            $dataRow = $this->dataRow($productDataType, $key);
+            if (!$dataRow->exists) {
+                $dataRow->fill($field)->save();
+            }
+        });
+
+    }
+
+    /**
+     * Create the new menu entry using the configuration
+     * specified in the menuEntry() method. IF set to null
+     * then no menu entry is going to be created
+     *
+     * @return [type] [description]
+     */
+    public function createMenuItem()
+    {
+        if (empty($this->menuEntry())) {
+            return;
+        }
+        $menuEntry = collect($this->menuEntry());
+
+        if (empty($menuEntry->menu_id)) {
+            $menu = Menu::where('name', $menuEntry->get('role'))->firstOrFail();
+            $menuEntry = $menuEntry->put('menu_id', $menu->id);
+        }
+
+        $menuItem = MenuItem::firstOrNew($menuEntry->only(['menu_id', 'title', 'url', 'route'])->toArray());
+        if (!$menuItem->exists) {
+            $menuItem->fill($menuEntry->only(['target', 'icon_class', 'color', 'parent_id', 'order'])->toArray())->save();
+        }
+    }
+
+    /**
+     * Generates admin permissions to the current
+     * bread
+     *
+     * @return void
+     */
+    public function generatePermissions()
+    {
+        Permission::generateFor($this->bread()['name']);
+    }
+
+    /**
+     * Find or create a new data-type
+     *
+     * @param  string $field Field name
+     * @param  string $for   Bread name
+     *
+     * @return DataType::class
+     */
+    protected function dataType($field, $for)
+    {
+        return DataType::firstOrNew([$field => $for]);
+    }
+
+    /**
+     * Find or create a new data-row
+     *
+     * @param  string $type  Type name
+     * @param  string $field Field name
+     *
+     * @return DataType::class
+     */
+    protected function dataRow($type, $field)
+    {
+        return DataRow::firstOrNew([
+                'data_type_id' => $type->id,
+                'field'        => $field,
+            ]);
+    }
+}

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -331,6 +331,7 @@ class VoyagerServiceProvider extends ServiceProvider
         $this->commands(Commands\InstallCommand::class);
         $this->commands(Commands\ControllersCommand::class);
         $this->commands(Commands\AdminCommand::class);
+        $this->commands(Commands\BreadGenerator::class);
     }
 
     /**

--- a/stubs/bread.stub
+++ b/stubs/bread.stub
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use TCG\Voyager\Traits\BreadSeeder;
+
+class DummyClassBreadSeeder extends Seeder
+{
+    use BreadSeeder;
+
+    public function bread()
+    {
+        return [
+            // usually the name of the table
+            'name'                  => 'DummySnakeCaseSingular',
+            'display_name_singular' => 'DummyStudlyCaseSingular',
+            'display_name_plural'   => 'DummyStudlyCasePlural',
+            'icon'                  => '',
+            'model_name'            => 'App\DummyStudlyCaseSingular',
+            'controller'            => '',
+            'generate_permissions'  => 1,
+            'description'           => '',
+        ];
+    }
+
+    public function inputFields()
+    {
+        return [
+            'id' => [
+                'type'         => 'number',
+                'display_name' => 'ID',
+                'required'     => 1,
+                'browse'       => 0,
+                'read'         => 0,
+                'edit'         => 0,
+                'add'          => 0,
+                'delete'       => 0,
+                'details'      => '',
+                'order'        => 1,
+            ],
+            'created_at' => [
+                'type'         => 'timestamp',
+                'display_name' => 'created_at',
+                'required'     => 0,
+                'browse'       => 1,
+                'read'         => 1,
+                'edit'         => 0,
+                'add'          => 0,
+                'delete'       => 0,
+                'details'      => '',
+                'order'        => 2,
+            ],
+            'updated_at' => [
+                'type'         => 'timestamp',
+                'display_name' => 'updated_at',
+                'required'     => 0,
+                'browse'       => 0,
+                'read'         => 0,
+                'edit'         => 0,
+                'add'          => 0,
+                'delete'       => 0,
+                'details'      => '',
+                'order'        => 3,
+            ]
+        ];
+    }
+
+    public function menuEntry()
+    {
+        return [
+            'role'      => 'admin',
+            'title'      => 'DummyStudlyCasePlural',
+            'url'        => '',
+            'route'      => 'voyager.DummySnakeCasePlural.index',
+            'target'     => '_self',
+            'icon_class' => 'voyager-basket',
+            'color'      => null,
+            'parent_id'  => null,
+            'order'      => 8,
+        ];
+    }
+}


### PR DESCRIPTION
There is a common issue when we try to deploy local projects to a different environment. Currently, we need to export the database or so, in order to keep all the new BREADs structure across all the environments.

The only way to do that without having to create a database import each time is by creating the migrations, seeds, etc. for each bread.

This allows the developers to create new BREADs from the command line using Artisan.

## How to use:

1. create a new bread
`php artisan voyager:bread books`

You can also generate the model and migration files

`php artisan voyager:bread books --migration --model`

2. Configure the bread
This command will create a new `BooksBreadSeeder` file with the basic configuration for a new bread-seed, there you can add/edit all the bread fields. See [DataRowsTableSeeder](https://github.com/the-control-group/voyager/blob/master/publishable/database/seeds/DataRowsTableSeeder.php)

3. Once the seeder is done you need to run:
`php artisan db:seed --class=BooksBreadSeeder`

4. Optionally you need to re-generate the permissions from the command line
`php artisan db:seed --class=PermissionRoleTableSeeder`
You can also do this manually from the admin panel

5. Don't forget to run the new migration
`php artisan migrate`

## Related issues
[https://github.com/the-control-group/voyager/issues/1477](https://github.com/the-control-group/voyager/issues/1477)

[https://github.com/the-control-group/voyager/issues/1921](https://github.com/the-control-group/voyager/issues/1921)

