### PR TITLE
fix: Display absolute URL images in formfield/image. Closes #2024.

### DIFF
--- a/resources/views/formfields/image.blade.php
+++ b/resources/views/formfields/image.blade.php
@@ -1,5 +1,5 @@
 @if(isset($dataTypeContent->{$row->field}))
-    <img src="{{ Voyager::image($dataTypeContent->{$row->field}) }}"
+    <img src="@if( !filter_var($dataTypeContent->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $dataTypeContent->{$row->field} ) }}@else{{ $dataTypeContent->{$row->field} }}@endif"
          style="width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:10px;">
 @endif
 <input @if($row->required == 1 && !isset($dataTypeContent->{$row->field})) required @endif type="file" name="{{ $row->field }}">


### PR DESCRIPTION
Adopted the same mechanism in [browse.blade.php](https://github.com/the-control-group/voyager/blob/a65e3c15e397ec4ee9c7458fcfc837561001269b/resources/views/bread/browse.blade.php#L87).