### PR TITLE
Strictly require password if no value exists. Closes #1999.

### DIFF
--- a/resources/views/formfields/password.blade.php
+++ b/resources/views/formfields/password.blade.php
@@ -3,7 +3,7 @@
     <small>{{ __('voyager.form.field_password_keep') }}</small>
 @endif
 <input type="password"
-       @if($row->required == 1) required @endif
+       @if($row->required == 1 && !isset($dataTypeContent->{$row->field})) required @endif
        class="form-control"
        name="{{ $row->field }}"
        value="">


### PR DESCRIPTION
Same bug as was resolved for image field in pull 2003 (https://github.com/the-control-group/voyager/pull/2003).