### PR TITLE
Fix to: Profile page cannot load absolute url avatars.

### DIFF
--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -14,7 +14,8 @@
     <div style="background-size:cover; background-image: url({{ Voyager::image( Voyager::setting('admin.bg_image'), config('voyager.assets_path') . '/images/bg.jpg') }}); background-position: center center;position:absolute; top:0; left:0; width:100%; height:300px;"></div>
     <div style="height:160px; display:block; width:100%"></div>
     <div style="position:relative; z-index:9; text-align:center;">
-        <img src="{{ Voyager::image( Auth::user()->avatar ) }}" class="avatar"
+        <img src="@if( !filter_var(Auth::user()->avatar, FILTER_VALIDATE_URL)){{ Voyager::image( Auth::user()->avatar ) }}@else{{ Auth::user()->avatar }}@endif"
+             class="avatar"
              style="border-radius:50%; width:150px; height:150px; border:5px solid #fff;"
              alt="{{ Auth::user()->name }} avatar">
         <h4>{{ ucwords(Auth::user()->name) }}</h4>


### PR DESCRIPTION
The sidebar and user profile dropdown (top right) have no problems displaying absolute URLs, so only this view is affected.