### PR TITLE
Added ability to create custom permission per table

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -22,6 +22,16 @@ class Permission extends Model
         self::firstOrCreate(['key' => 'delete_'.$table_name, 'table_name' => $table_name]);
     }
 
+    /**
+     * Generate custom permission for table
+     * @param $table_name
+     * @param $permission
+     */
+    public static function generateCustomFor($table_name, $permission)
+    {
+        self::firstOrCreate(['key' => $permission.'_'.$table_name, 'table_name' => $table_name]);
+    }
+
     public static function removeFrom($table_name)
     {
         self::where(['table_name' => $table_name])->delete();

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -24,7 +24,7 @@ class Permission extends Model
 
     /**
      * Generate custom permission for table.
-     * 
+     *
      * @param $table_name
      * @param $permission
      */

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -23,7 +23,8 @@ class Permission extends Model
     }
 
     /**
-     * Generate custom permission for table
+     * Generate custom permission for table.
+     * 
      * @param $table_name
      * @param $permission
      */


### PR DESCRIPTION
Hi, 

Were busy implementing a workflow for certain roles that required some additional (custom) permissions. EG the ability to restrict publishing. As we work in a team these permissions get added from a seed

Usage example: Permission::generateCustomFor('post', 'publish')