### PR TITLE
fix: In insert/update, skip fields which are not present in the form (except for checkboxes). Closes #2039.

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -54,7 +54,9 @@ abstract class Controller extends BaseController
 
             // if the field for this row is absent from the request, continue
             // checkboxes will be absent when unchecked, thus they are the exception
-            if (!$request->has($row->field) && $row->type !== 'checkbox') continue;
+            if (!$request->has($row->field) && $row->type !== 'checkbox') {
+                continue;
+            }
 
             $content = $this->getContentBasedOnType($request, $slug, $row);
 

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -52,6 +52,10 @@ abstract class Controller extends BaseController
                 $row->field = @$options->column;
             }
 
+            // if the field for this row is absent from the request, continue
+            // checkboxes will be absent when unchecked, thus they are the exception
+            if (!$request->has($row->field) && $row->type !== 'checkbox') continue;
+
             $content = $this->getContentBasedOnType($request, $slug, $row);
 
             /*


### PR DESCRIPTION
Fix for #2039 

With this commit, a column will be updated only if its corresponding field
is present in the request. The exception here being a checkbox which
depending on the browser may or may not show up in the request.