### PR TITLE
Analytics dashboard: select correct property ID

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -169,7 +169,8 @@
                  * element with the id "view-selector-container".
                  */
                 var viewSelector = new gapi.analytics.ext.ViewSelector2({
-                    container: 'view-selector-container'
+                    container: 'view-selector-container',
+                    propertyId: '{{ Voyager::setting("site.google_analytics_tracking_id")  }}'
                 })
                         .execute();
 


### PR DESCRIPTION
Currently, the Analytics dashboard of Voyager just shows the first Property of the Analytics account:

![image](https://user-images.githubusercontent.com/1945577/31852457-430bb818-b678-11e7-9c3b-abe00b650701.png)


This change automatically selects the correct property, based on the `site.google_analytics_tracking_id` setting.