### PR TITLE
Add missing translation string

### DIFF
--- a/publishable/lang/de/voyager.php
+++ b/publishable/lang/de/voyager.php
@@ -239,6 +239,7 @@ return [
         'already_exists_table'      => 'Tabelle :table existiert bereits',
         'bread_crud_actions'        => 'BREAD/CRUD Aktionen',
         'bread_info'                => 'BREAD Info',
+        'browse_bread'              => 'BREAD ansehen'
         'column'                    => 'Spalte',
         'composite_warning'         => 'Warnung: Diese Spalte ist Teil eines zusammengesetzten indexes',
         'controller_name'           => 'Controller Name',

--- a/publishable/lang/de/voyager.php
+++ b/publishable/lang/de/voyager.php
@@ -239,7 +239,7 @@ return [
         'already_exists_table'      => 'Tabelle :table existiert bereits',
         'bread_crud_actions'        => 'BREAD/CRUD Aktionen',
         'bread_info'                => 'BREAD Info',
-        'browse_bread'              => 'BREAD ansehen'
+        'browse_bread'              => 'BREAD ansehen',
         'column'                    => 'Spalte',
         'composite_warning'         => 'Warnung: Diese Spalte ist Teil eines zusammengesetzten indexes',
         'controller_name'           => 'Controller Name',

--- a/publishable/lang/en/voyager.php
+++ b/publishable/lang/en/voyager.php
@@ -244,6 +244,7 @@ return [
         'already_exists_table'      => 'Table :table already exists',
         'bread_crud_actions'        => 'BREAD/CRUD Actions',
         'bread_info'                => 'BREAD info',
+        'browse_bread'              => 'Browse BREAD',
         'column'                    => 'Column',
         'composite_warning'         => 'Warning: this column is part of a composite index',
         'controller_name'           => 'Controller Name',


### PR DESCRIPTION
New language string introduced [here](https://github.com/the-control-group/voyager/commit/e8ba2b4cbcda1b2971f2748d606c3da28c406b6e#diff-753f72db10e0956cee2c0f4c254b780d) was never implemented in language files.