### PR TITLE
Fixed the autoselect on belongs to relationship

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -28,7 +28,7 @@
 	            		$query = $model::all();
 	            	@endphp
 					@foreach($query as $relationshipData)
-						<option value="{{ $relationshipData->{$options->key} }}" @if($dataTypeContent->{$relationshipField} == $relationshipData->{$options->key}){{ 'selected="selected"' }}@endif>{{ $relationshipData->{$options->label} }}</option>
+						<option value="{{ $relationshipData->{$options->key} }}" @if($dataTypeContent->{$options->column} == $relationshipData->{$options->key}){{ 'selected="selected"' }}@endif>{{ $relationshipData->{$options->label} }}</option>
 					@endforeach
 				</select>
 


### PR DESCRIPTION
The select field was using the name of the relationship field (something like costume_belongsto_size_relationship) instead of the foreign key, this prevented the preselection of the actual value from being set.