### PR TITLE
Removing scalar typehints as they're not supported before PHP 7.0

### DIFF
--- a/src/Events/BreadChanged.php
+++ b/src/Events/BreadChanged.php
@@ -15,7 +15,7 @@ class BreadChanged
 
     public $changeType;
 
-    public function __construct(DataType $dataType, $data, string $changeType)
+    public function __construct(DataType $dataType, $data, $changeType)
     {
         $this->dataType = $dataType;
 

--- a/src/Events/BreadDataChanged.php
+++ b/src/Events/BreadDataChanged.php
@@ -15,7 +15,7 @@ class BreadDataChanged
 
     public $changeType;
 
-    public function __construct(DataType $dataType, $data, string $changeType)
+    public function __construct(DataType $dataType, $data, $changeType)
     {
         $this->dataType = $dataType;
 

--- a/src/Events/TableChanged.php
+++ b/src/Events/TableChanged.php
@@ -10,7 +10,7 @@ class TableChanged
 
     public $name;
 
-    public function __construct(string $name)
+    public function __construct($name)
     {
         $this->name = $name;
     }

--- a/src/Events/TableDeleted.php
+++ b/src/Events/TableDeleted.php
@@ -10,7 +10,7 @@ class TableDeleted
 
     public $name;
 
-    public function __construct(string $name)
+    public function __construct($name)
     {
         $this->name = $name;
 


### PR DESCRIPTION
Fixes #2099 