### PR TITLE
Relationship table selection overwrites $table

### DIFF
--- a/resources/views/tools/database/relationship-partial.blade.php
+++ b/resources/views/tools/database/relationship-partial.blade.php
@@ -44,8 +44,8 @@
                 <option value="belongsToMany" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'belongsToMany'){{ 'selected="selected"' }}@endif>{{ __('voyager.database.relationship.belongs_to_many') }}</option>
             </select>
             <select class="relationship_table select2" name="relationship_table_{{ $relationship['field'] }}">
-                @foreach($tables as $table)
-                    <option value="{{ $table }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $table){{ 'selected="selected"' }}@endif>{{ ucfirst($table) }}</option>
+                @foreach($tables as $tablename)
+                    <option value="{{ $tablename }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tablename){{ 'selected="selected"' }}@endif>{{ ucfirst($tablename) }}</option>
                 @endforeach
             </select>
             <span><input type="text" class="form-control" name="relationship_model_{{ $relationship['field'] }}" placeholder="{{ __('voyager.database.relationship.namespace') }}" value="@if(isset($relationshipDetails->model)){{ $relationshipDetails->model }}@endif"></span>


### PR DESCRIPTION
The table select overwrites the $table which is used on line 55 in a belongsto relationship.
Instead of the selected table it will show the last table from the foreach loop