### PR TITLE
Separate database connections for voyager and other tables to BREAD

### DIFF
--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TCG\Voyager\Auth;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    public function __construct()
+    {
+        $voyagerDBConn = config('voyager.database.connection');
+
+        if ($voyagerDBConn) {
+            $this->connection = $voyagerDBConn;
+        }
+
+        parent::__construct(...func_get_args());
+    }
+}

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TCG\Voyager\Database;
+
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+
+class Model extends EloquentModel
+{
+    public function __construct()
+    {
+        $voyagerDBConn = config('voyager.database.connection');
+
+        if ($voyagerDBConn) {
+            $this->connection = $voyagerDBConn;
+        }
+
+        parent::__construct(...func_get_args());
+    }
+}

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -2,7 +2,7 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use TCG\Voyager\Database\Model;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Traits\Translatable;
 

--- a/src/Models/DataRow.php
+++ b/src/Models/DataRow.php
@@ -2,7 +2,7 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use TCG\Voyager\Database\Model;
 
 class DataRow extends Model
 {

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -2,8 +2,8 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+use TCG\Voyager\Database\Model;
 use TCG\Voyager\Database\Schema\SchemaManager;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Traits\Translatable;

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -2,8 +2,8 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use TCG\Voyager\Database\Model;
 use TCG\Voyager\Events\MenuDisplay;
 use TCG\Voyager\Facades\Voyager;
 

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -2,8 +2,8 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Route;
+use TCG\Voyager\Database\Model;
 use TCG\Voyager\Traits\Translatable;
 
 class MenuItem extends Model

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -2,8 +2,8 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use TCG\Voyager\Database\Model;
 use TCG\Voyager\Traits\Translatable;
 
 class Page extends Model

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -2,7 +2,7 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use TCG\Voyager\Database\Model;
 
 class Permission extends Model
 {

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -3,8 +3,8 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use TCG\Voyager\Database\Model;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Traits\Translatable;
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -2,7 +2,7 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use TCG\Voyager\Database\Model;
 use TCG\Voyager\Facades\Voyager;
 
 class Role extends Model

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -2,7 +2,7 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use TCG\Voyager\Database\Model;
 
 class Setting extends Model
 {

--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -2,7 +2,7 @@
 
 namespace TCG\Voyager\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use TCG\Voyager\Database\Model;
 
 class Translation extends Model
 {

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -3,7 +3,7 @@
 namespace TCG\Voyager\Models;
 
 use Carbon\Carbon;
-use Illuminate\Foundation\Auth\User as Authenticatable;
+use TCG\Voyager\Auth\User as Authenticatable;
 use TCG\Voyager\Contracts\User as UserContract;
 use TCG\Voyager\Traits\VoyagerUser;
 

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -270,7 +270,15 @@ class VoyagerServiceProvider extends ServiceProvider
         // otherwise it will throw an error because no database
         // connection has been made yet.
         try {
-            if (Schema::hasTable('data_types')) {
+            $voyagerDBConn = config('voyager.database.connection');
+
+            if (empty($voyagerDBConn)) {
+                $hasDataTypeTable = Schema::hasTable('data_types');
+            } else {
+                $hasDataTypeTable = Schema::connection($voyagerDBConn)->hasTable('data_types');
+            }
+
+            if ($hasDataTypeTable) {
                 $dataType = VoyagerFacade::model('DataType');
                 $dataTypes = $dataType->get();
 
@@ -283,7 +291,6 @@ class VoyagerServiceProvider extends ServiceProvider
 
                     $this->policies[$dataType->model_name] = $policyClass;
                 }
-
                 $this->registerPolicies();
             }
         } catch (\PDOException $e) {


### PR DESCRIPTION
Hi, I'm trying to use Voyager as admin console of a database and I saw the issue #69 trying to use the same feature.

I made a different base class of `Model` and `User` that gets the `$connection` property from `voyager.database.connection` config.

Steps to use it:

1. Configure both db, voyager and main in `config/database.php`
2. Set voyager db connection as default in `config/database.php`
3. Install voyager `artisan voyager:install` 
4. Set `voyager.database.connection` variable as voyager db connection in `config/voyager.php`
5. Set main db connection as default in `config/database.php`
