### PR TITLE
Feature User Multi Roles

### DIFF
--- a/publishable/database/migrations/2017_11_26_013050_add_user_role_relationship.php
+++ b/publishable/database/migrations/2017_11_26_013050_add_user_role_relationship.php
@@ -14,7 +14,7 @@ class AddUserRoleRelationship extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->unsignedInteger('role_id')->nullable(false)->change();
+            $table->unsignedInteger('role_id')->change();
             $table->foreign('role_id')->references('id')->on('roles');
         });
     }
@@ -27,6 +27,7 @@ class AddUserRoleRelationship extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
+            $table->integer('role_id')->change();
             $table->dropForeign(['role_id']);
         });
     }

--- a/publishable/database/migrations/2017_11_26_013050_add_user_role_relationship.php
+++ b/publishable/database/migrations/2017_11_26_013050_add_user_role_relationship.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserRoleRelationship extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedInteger('role_id')->nullable(false)->change();
+            $table->foreign('role_id')->references('id')->on('roles');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['role_id']);
+        });
+    }
+}

--- a/publishable/database/migrations/2017_11_26_014010_drop_permission_groups_table.php
+++ b/publishable/database/migrations/2017_11_26_014010_drop_permission_groups_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropPermissionGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->dropColumn('permission_group_id');
+        });
+
+        Schema::dropIfExists('permission_groups');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->integer('permission_group_id')->unsigned()->nullable()->default(null);
+        });
+
+        Schema::create('permission_groups', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->unique();
+        });
+    }
+}

--- a/publishable/database/migrations/2017_11_26_015000_create_user_roles_table.php
+++ b/publishable/database/migrations/2017_11_26_015000_create_user_roles_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserRolesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_roles', function (Blueprint $table) {
+            $table->integer('user_id')->unsigned()->index();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->integer('role_id')->unsigned()->index();
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+            $table->primary(['user_id', 'role_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_roles');
+    }
+}

--- a/publishable/database/seeds/DataRowsTableSeeder.php
+++ b/publishable/database/seeds/DataRowsTableSeeder.php
@@ -528,22 +528,6 @@ class DataRowsTableSeeder extends Seeder
             ])->save();
         }
 
-        $dataRow = $this->dataRow($userDataType, 'user_belongsto_role_relationship');
-        if (!$dataRow->exists) {
-            $dataRow->fill([
-                'type'         => 'relationship',
-                'display_name' => 'Role',
-                'required'     => 0,
-                'browse'       => 1,
-                'read'         => 1,
-                'edit'         => 1,
-                'add'          => 1,
-                'delete'       => 0,
-                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsTo","column":"role_id","key":"id","label":"name","pivot_table":"roles","pivot":"0"}',
-                'order'        => 10,
-            ])->save();
-        }
-
         $dataRow = $this->dataRow($userDataType, 'remember_token');
         if (!$dataRow->exists) {
             $dataRow->fill([
@@ -605,6 +589,38 @@ class DataRowsTableSeeder extends Seeder
                 'delete'       => 1,
                 'details'      => '',
                 'order'        => 8,
+            ])->save();
+        }
+
+        $dataRow = $this->dataRow($userDataType, 'user_belongsto_role_relationship');
+        if (!$dataRow->exists) {
+            $dataRow->fill([
+                'type'         => 'relationship',
+                'display_name' => 'Role',
+                'required'     => 0,
+                'browse'       => 1,
+                'read'         => 1,
+                'edit'         => 1,
+                'add'          => 1,
+                'delete'       => 0,
+                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsTo","column":"role_id","key":"id","label":"name","pivot_table":"roles","pivot":"0"}',
+                'order'        => 10,
+            ])->save();
+        }
+
+        $dataRow = $this->dataRow($userDataType, 'user_belongstomany_role_relationship');
+        if (!$dataRow->exists) {
+            $dataRow->fill([
+                'type'         => 'relationship',
+                'display_name' => 'Roles',
+                'required'     => 0,
+                'browse'       => 1,
+                'read'         => 1,
+                'edit'         => 1,
+                'add'          => 1,
+                'delete'       => 0,
+                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsToMany","column":"id","key":"id","label":"name","pivot_table":"user_roles","pivot":"1"}',
+                'order'        => 11,
             ])->save();
         }
 

--- a/publishable/lang/en/voyager.php
+++ b/publishable/lang/en/voyager.php
@@ -104,13 +104,16 @@ return [
     ],
 
     'profile' => [
-        'avatar'        => 'Avatar',
-        'edit'          => 'Edit My Profile',
-        'edit_user'     => 'Edit User',
-        'password'      => 'Password',
-        'password_hint' => 'Leave empty to keep the same',
-        'role'          => 'Role',
-        'user_role'     => 'User Role',
+        'avatar'           => 'Avatar',
+        'edit'             => 'Edit My Profile',
+        'edit_user'        => 'Edit User',
+        'password'         => 'Password',
+        'password_hint'    => 'Leave empty to keep the same',
+        'role'             => 'Role',
+        'roles'            => 'Roles',
+        'role_default'     => 'Default Role',
+        'roles_additional' => 'Additional Roles',
+        'user_role'        => 'User Role',
     ],
 
     'settings' => [

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -104,35 +104,38 @@
                                 <input type="password" class="form-control" id="password" name="password" value="">
                             </div>
 
-                            <div class="form-group">
-                                <label for="avatar">{{ __('voyager.profile.avatar') }}</label>
-                                @if(isset($dataTypeContent->avatar))
-                                    <img src="{{ filter_var($dataTypeContent->avatar, FILTER_VALIDATE_URL) ? $dataTypeContent->avatar : Voyager::image( $dataTypeContent->avatar ) }}" style="width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:10px;" />
-                                @endif
-                                <input type="file" data-name="avatar" name="avatar">
-                            </div>
+                            @can('editRoles', $dataTypeContent)
+                                <div class="form-group">
+                                    <label for="name">{{ __('voyager.profile.role_default') }}</label>
+                                    @php
+                                        $dataTypeRows = $dataType->{(isset($dataTypeContent->id) ? 'editRows' : 'addRows' )};
+
+                                        $row     = $dataTypeRows->where('field', 'user_belongsto_role_relationship')->first();
+                                        $options = json_decode($row->details);
+                                    @endphp
+                                    @include('voyager::formfields.relationship')
+                                </div>
+                                <div class="form-group">
+                                    <label for="name">{{ __('voyager.generic.roles_additional') }}</label>
+                                    @php
+                                        $row     = $dataTypeRows->where('field', 'user_belongstomany_role_relationship')->first();
+                                        $options = json_decode($row->details);
+                                    @endphp
+                                    @include('voyager::formfields.relationship')
+                                </div>
+                            @endcan
                         </div>
                     </div>
                 </div>
 
                 <div class="col-md-4">
                     <div class="panel panel panel-bordered panel-warning">
-                        <div class="panel-heading">
-                            <h3 class="panel-title"><i class="icon voyager-lock"></i> Roles</h3>
-                        </div>
                         <div class="panel-body">
                             <div class="form-group">
-                                <label for="name">{{ __('voyager.profile.role_default') }}</label>
-                                @php
-                                    $dataTypeRows = $dataType->{(isset($dataTypeContent->id) ? 'editRows' : 'addRows' )};
-                                    $row = $dataTypeRows->where('field', 'user_belongsto_role_relationship')->first();
-
-                                    $options = json_decode($row->details);
-                                @endphp
-                                @include('voyager::formfields.relationship')
-                            </div>
-                            <div class="form-group">
-                                <label for="name">{{ __('voyager.generic.roles_additional') }}</label>
+                                @if(isset($dataTypeContent->avatar))
+                                    <img src="{{ filter_var($dataTypeContent->avatar, FILTER_VALIDATE_URL) ? $dataTypeContent->avatar : Voyager::image( $dataTypeContent->avatar ) }}" style="width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:10px;" />
+                                @endif
+                                <input type="file" data-name="avatar" name="avatar">
                             </div>
                         </div>
                     </div>

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -72,7 +72,7 @@
                                     @include('voyager::formfields.relationship')
                                 </div>
                                 <div class="form-group">
-                                    <label for="name">{{ __('voyager.generic.roles_additional') }}</label>
+                                    <label for="name">{{ __('voyager.profile.roles_additional') }}</label>
                                     @php
                                         $row     = $dataTypeRows->where('field', 'user_belongstomany_role_relationship')->first();
                                         $options = json_decode($row->details);

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -1,0 +1,162 @@
+@extends('voyager::master')
+
+@section('page_title', __('voyager.generic.'.(isset($dataTypeContent->id) ? 'edit' : 'add')).' '.$dataType->display_name_singular)
+
+@section('css')
+    <style>
+        .panel .mce-panel {
+            border-left-color: #fff;
+            border-right-color: #fff;
+        }
+
+        .panel .mce-toolbar,
+        .panel .mce-statusbar {
+            padding-left: 20px;
+        }
+
+        .panel .mce-edit-area,
+        .panel .mce-edit-area iframe,
+        .panel .mce-edit-area iframe html {
+            padding: 0 10px;
+            min-height: 350px;
+        }
+
+        .mce-content-body {
+            color: #555;
+            font-size: 14px;
+        }
+
+        .panel.is-fullscreen .mce-statusbar {
+            position: absolute;
+            bottom: 0;
+            width: 100%;
+            z-index: 200000;
+        }
+
+        .panel.is-fullscreen .mce-tinymce {
+            height:100%;
+        }
+
+        .panel.is-fullscreen .mce-edit-area,
+        .panel.is-fullscreen .mce-edit-area iframe,
+        .panel.is-fullscreen .mce-edit-area iframe html {
+            height: 100%;
+            position: absolute;
+            width: 99%;
+            overflow-y: scroll;
+            overflow-x: hidden;
+            min-height: 100%;
+        }
+    </style>
+@stop
+
+@section('page_header')
+    <h1 class="page-title">
+        <i class="{{ $dataType->icon }}"></i>
+        {{ __('voyager.generic.'.(isset($dataTypeContent->id) ? 'edit' : 'add')).' '.$dataType->display_name_singular }}
+    </h1>
+@stop
+
+@section('content')
+    <div class="page-content container-fluid">
+        <form class="form-edit-add" role="form"
+              action="{{ (isset($dataTypeContent->id)) ? route('voyager.'.$dataType->slug.'.update', $dataTypeContent->id) : route('voyager.'.$dataType->slug.'.store') }}"
+              method="POST" enctype="multipart/form-data">
+            <!-- PUT Method if we are editing -->
+            @if(isset($dataTypeContent->id))
+                {{ method_field("PUT") }}
+            @endif
+            {{ csrf_field() }}
+
+            <div class="row">
+                <div class="col-md-8">
+                    <div class="panel panel-bordered">
+                    {{-- <div class="panel"> --}}
+                        @if (count($errors) > 0)
+                            <div class="alert alert-danger">
+                                <ul>
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        <div class="panel-body">
+                            <div class="form-group">
+                                <label for="name">{{ __('voyager.generic.name') }}</label>
+                                <input type="text" class="form-control" id="name" name="name" placeholder="{{ __('voyager.generic.name') }}"
+                                       value="@if(isset($dataTypeContent->name)){{ $dataTypeContent->name }}@endif">
+                            </div>
+
+                            <div class="form-group">
+                                <label for="email">{{ __('voyager.generic.email') }}</label>
+                                <input type="email" class="form-control" id="email" name="email" placeholder="{{ __('voyager.generic.email') }}"
+                                       value="@if(isset($dataTypeContent->email)){{ $dataTypeContent->email }}@endif">
+                            </div>
+
+                            <div class="form-group">
+                                <label for="password">{{ __('voyager.generic.password') }}</label>
+                                @if(isset($dataTypeContent->password))
+                                    <br>
+                                    <small>Leave empty to keep the same</small>
+                                @endif
+                                <input type="password" class="form-control" id="password" name="password" value="">
+                            </div>
+
+                            <div class="form-group">
+                                <label for="avatar">{{ __('voyager.profile.avatar') }}</label>
+                                @if(isset($dataTypeContent->avatar))
+                                    <img src="{{ filter_var($dataTypeContent->avatar, FILTER_VALIDATE_URL) ? $dataTypeContent->avatar : Voyager::image( $dataTypeContent->avatar ) }}" style="width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:10px;" />
+                                @endif
+                                <input type="file" data-name="avatar" name="avatar">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-md-4">
+                    <div class="panel panel panel-bordered panel-warning">
+                        <div class="panel-heading">
+                            <h3 class="panel-title"><i class="icon voyager-lock"></i> Roles</h3>
+                        </div>
+                        <div class="panel-body">
+                            <div class="form-group">
+                                <label for="name">{{ __('voyager.profile.role_default') }}</label>
+                                @php
+                                    $dataTypeRows = $dataType->{(isset($dataTypeContent->id) ? 'editRows' : 'addRows' )};
+                                    $row = $dataTypeRows->where('field', 'user_belongsto_role_relationship')->first();
+
+                                    $options = json_decode($row->details);
+                                @endphp
+                                @include('voyager::formfields.relationship')
+                            </div>
+                            <div class="form-group">
+                                <label for="name">{{ __('voyager.generic.roles_additional') }}</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <button type="submit" class="btn btn-primary pull-right save">
+                {{ __('voyager.generic.save') }}
+            </button>
+        </form>
+
+        <iframe id="form_target" name="form_target" style="display:none"></iframe>
+        <form id="my_form" action="{{ route('voyager.upload') }}" target="form_target" method="post" enctype="multipart/form-data" style="width:0px;height:0;overflow:hidden">
+            {{ csrf_field() }}
+            <input name="image" id="upload_file" type="file" onchange="$('#my_form').submit();this.value='';">
+            <input type="hidden" name="type_slug" id="type_slug" value="{{ $dataType->slug }}">
+        </form>
+    </div>
+@stop
+
+@section('javascript')
+    <script>
+        $('document').ready(function () {
+            $('.toggleswitch').bootstrapToggle();
+        });
+    </script>
+@stop

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -3,51 +3,7 @@
 @section('page_title', __('voyager.generic.'.(isset($dataTypeContent->id) ? 'edit' : 'add')).' '.$dataType->display_name_singular)
 
 @section('css')
-    <style>
-        .panel .mce-panel {
-            border-left-color: #fff;
-            border-right-color: #fff;
-        }
-
-        .panel .mce-toolbar,
-        .panel .mce-statusbar {
-            padding-left: 20px;
-        }
-
-        .panel .mce-edit-area,
-        .panel .mce-edit-area iframe,
-        .panel .mce-edit-area iframe html {
-            padding: 0 10px;
-            min-height: 350px;
-        }
-
-        .mce-content-body {
-            color: #555;
-            font-size: 14px;
-        }
-
-        .panel.is-fullscreen .mce-statusbar {
-            position: absolute;
-            bottom: 0;
-            width: 100%;
-            z-index: 200000;
-        }
-
-        .panel.is-fullscreen .mce-tinymce {
-            height:100%;
-        }
-
-        .panel.is-fullscreen .mce-edit-area,
-        .panel.is-fullscreen .mce-edit-area iframe,
-        .panel.is-fullscreen .mce-edit-area iframe html {
-            height: 100%;
-            position: absolute;
-            width: 99%;
-            overflow-y: scroll;
-            overflow-x: hidden;
-            min-height: 100%;
-        }
-    </style>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 @stop
 
 @section('page_header')

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -9,19 +9,14 @@ class Role extends Model
 {
     protected $guarded = [];
 
-    public function usersDefault()
-    {
-        return $this->hasMany(Voyager::modelClass('User'))->select('*');
-    }
-
-    public function usersAlternative()
-    {
-        return $this->belongsToMany(Voyager::modelClass('User'), 'user_roles')->select('users.*');
-    }
-
     public function users()
     {
-        return $this->usersDefault()->union($this->usersAlternative()->toBase());
+        return $this->hasMany(Voyager::modelClass('User'))->select('*')->getQuery()
+                    ->union(
+                        $this->belongsToMany(Voyager::modelClass('User'), 'user_roles')
+                             ->select(Voyager::model('User')->getTable().'.*')
+                             ->getQuery()
+                    );
     }
 
     public function permissions()

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -9,10 +9,19 @@ class Role extends Model
 {
     protected $guarded = [];
 
+    public function usersDefault()
+    {
+        return $this->hasMany(Voyager::modelClass('User'))->select('*');
+    }
+
+    public function usersAlternative()
+    {
+        return $this->belongsToMany(Voyager::modelClass('User'), 'user_roles')->select('users.*');
+    }
+
     public function users()
     {
-        return $this->hasMany(Voyager::modelClass('User'))->get()
-                    ->merge($this->belongsToMany(Voyager::modelClass('User'), 'user_roles')->get());
+        return $this->usersDefault()->union($this->usersAlternative()->toBase());
     }
 
     public function permissions()

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -11,12 +11,11 @@ class Role extends Model
 
     public function users()
     {
-        return $this->hasMany(Voyager::modelClass('User'))->select('*')->getQuery()
-                    ->union(
-                        $this->belongsToMany(Voyager::modelClass('User'), 'user_roles')
-                             ->select(Voyager::model('User')->getTable().'.*')
-                             ->getQuery()
-                    );
+        $userModel = Voyager::modelClass('User');
+
+        return $this->belongsToMany($userModel, 'user_roles')
+                    ->select(app($userModel)->getTable().'.*')
+                    ->union($this->hasMany($userModel))->getQuery();
     }
 
     public function permissions()

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -11,7 +11,8 @@ class Role extends Model
 
     public function users()
     {
-        return $this->belongsToMany(Voyager::modelClass('User'), 'user_roles');
+        return $this->hasMany(Voyager::modelClass('User'))->get()
+                    ->merge($this->belongsToMany(Voyager::modelClass('User'), 'user_roles')->get());
     }
 
     public function permissions()

--- a/src/Policies/UserPolicy.php
+++ b/src/Policies/UserPolicy.php
@@ -16,7 +16,7 @@ class UserPolicy extends BasePolicy
      */
     public function read(User $user, $model)
     {
-        // Does this post belong to the current user?
+        // Does this record belong to the current user?
         $current = $user->id === $model->id;
 
         return $current || $this->checkPermission($user, $model, 'read');
@@ -32,9 +32,22 @@ class UserPolicy extends BasePolicy
      */
     public function edit(User $user, $model)
     {
-        // Does this post belong to the current user?
+        // Does this record belong to the current user?
         $current = $user->id === $model->id;
 
         return $current || $this->checkPermission($user, $model, 'edit');
+    }
+
+    /**
+     * Determine if the given user can change a user a role.
+     *
+     * @param \TCG\Voyager\Contracts\User $user
+     * @param  $model
+     *
+     * @return bool
+     */
+    public function editRoles(User $user, $model)
+    {
+        return $user->hasPermission('edit_users');
     }
 }

--- a/src/Policies/UserPolicy.php
+++ b/src/Policies/UserPolicy.php
@@ -48,6 +48,9 @@ class UserPolicy extends BasePolicy
      */
     public function editRoles(User $user, $model)
     {
-        return $user->hasPermission('edit_users');
+        // Does this record belong to another user?
+        $another = $user->id != $model->id;
+
+        return $another && $user->hasPermission('edit_users');
     }
 }

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -60,7 +60,7 @@ trait VoyagerUser
     }
 
     /**
-     * Set default User Role
+     * Set default User Role.
      *
      * @param string $name The role name to associate.
      */

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -11,8 +11,6 @@ use TCG\Voyager\Models\Role;
  */
 trait VoyagerUser
 {
-    protected $cache_permissions = [];
-
     /**
      * Return default User Role.
      */
@@ -78,9 +76,13 @@ trait VoyagerUser
 
     public function hasPermission($name)
     {
-        $this->loadPermissionsCache();
+        $this->loadPermissionsRelations();
 
-        return in_array($name, $this->cache_permissions);
+        $_permissions = $this->roles_all()
+                              ->pluck('permissions')->flatten()
+                              ->pluck('key')->unique()->toArray();
+
+        return in_array($name, $_permissions);
     }
 
     public function hasPermissionOrFail($name)
@@ -122,17 +124,6 @@ trait VoyagerUser
 
         if (!$this->relationLoaded('roles.permissions')) {
             $this->load('roles.permissions');
-        }
-    }
-
-    private function loadPermissionsCache()
-    {
-        $this->loadPermissionsRelations();
-
-        if (empty($this->cache_permissions)) {
-            $this->cache_permissions = $this->roles_all()
-                                            ->pluck('permissions')->flatten()
-                                            ->pluck('key')->unique()->toArray();
         }
     }
 }


### PR DESCRIPTION
Here follows my propose for User Multi Roles.

Note: A user, cannot, ever, change his own Role.

I have kept the field `users.role_id`, and it's used for the default User Role. We can't remove this field, or it would break all existing Voyager installations. 

The ideal solution is using a single table `users_roles`, my suggestion is to update this after we revise Voyager with the upgrade system, that will allow us to upgrade existing installations without any issues.

**Users Multi Roles / Permissions DB**
![image](https://user-images.githubusercontent.com/34574/33371829-e235f6a8-d4f3-11e7-81b5-41d129a92cfa.png)

Please test it and send feedback.

Closes #371
Closes #1150
Closes #1726
Closes #2192
