### PR TITLE
Fix / rich text box require

### DIFF
--- a/resources/views/formfields/rich_text_box.blade.php
+++ b/resources/views/formfields/rich_text_box.blade.php
@@ -1,4 +1,4 @@
-<textarea @if($row->required == 1) required @endif class="form-control richTextBox" data-name="{{ $row->display_name }}"  name="{{ $row->field }}" id="richtext{{ $row->field }}">
+<textarea @if($row->required == 1) @endif class="form-control richTextBox" data-name="{{ $row->display_name }}"  name="{{ $row->field }}" id="richtext{{ $row->field }}">
     @if(isset($dataTypeContent->{$row->field}))
         {{ old($row->field, $dataTypeContent->{$row->field}) }}
     @else

--- a/resources/views/formfields/rich_text_box.blade.php
+++ b/resources/views/formfields/rich_text_box.blade.php
@@ -1,4 +1,4 @@
-<textarea @if($row->required == 1) @endif class="form-control richTextBox" data-name="{{ $row->display_name }}"  name="{{ $row->field }}" id="richtext{{ $row->field }}">
+<textarea class="form-control richTextBox" data-name="{{ $row->display_name }}"  name="{{ $row->field }}" id="richtext{{ $row->field }}">
     @if(isset($dataTypeContent->{$row->field}))
         {{ old($row->field, $dataTypeContent->{$row->field}) }}
     @else


### PR DESCRIPTION
#2288, #1998
remove 'require' attribute from rich_text_box.blade.php, because:

> Chrome wants to focus on a control that is required but still empty so that it can pop up the message 'Please fill out this field'. However, if the control is hidden at the point that Chrome wants to pop up the message, that is at the time of form submission, Chrome can't focus on the control because it is hidden, therefore the form won't submit.
> 
> So, to get around the problem, when a control is hidden by javascript, we also must remove the 'required' attribute from that control.