### PR TITLE
Loading migrations by default, instead of publishing, on voyager::install

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -69,7 +69,11 @@ class InstallCommand extends Command
         $this->call('hook:setup');
 
         $this->info('Publishing the Voyager assets, database, language, and config files');
-        $this->call('vendor:publish', ['--provider' => VoyagerServiceProvider::class]);
+
+        //Publish only relevant resources on install
+        $tags = ['voyager_assets', 'seeds', 'demo_content', 'config', 'lang'];
+
+        $this->call('vendor:publish', ['--provider' => VoyagerServiceProvider::class, '--tag' => $tags]);
         $this->call('vendor:publish', ['--provider' => ImageServiceProviderLaravel5::class]);
 
         $this->info('Migrating the database tables into your application');

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -95,14 +95,11 @@ class VoyagerServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'voyager');
 
-        if (app()->version() >= 5.4) {
-            $router->aliasMiddleware('admin.user', VoyagerAdminMiddleware::class);
+        $router->aliasMiddleware('admin.user', VoyagerAdminMiddleware::class);
+        $this->loadMigrationsFrom(realpath(__DIR__.'/../publishable/database/migrations'));
 
-            if (config('app.env') == 'testing') {
-                $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
-            }
-        } else {
-            $router->middleware('admin.user', VoyagerAdminMiddleware::class);
+        if (config('app.env') == 'testing') {
+            $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
         }
 
         $this->registerGates();
@@ -234,9 +231,6 @@ class VoyagerServiceProvider extends ServiceProvider
         $publishable = [
             'voyager_assets' => [
                 "{$publishablePath}/assets/" => public_path(config('voyager.assets_path')),
-            ],
-            'migrations' => [
-                "{$publishablePath}/database/migrations/" => database_path('migrations'),
             ],
             'seeds' => [
                 "{$publishablePath}/database/seeds/" => database_path('seeds'),


### PR DESCRIPTION
Loading migrations from provider.
Updated install command for 5.4